### PR TITLE
Add toplevel `"types"` entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.module.js",
   "unpkg": "./dist/index.umd.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Fixes #20

**Description**

Turns out the toplevel entry `"types"` is needed (at least in my IDE):

```json
{
  "types": "./dist/index.d.ts",
}
```

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch