### PR TITLE
Feature: respect reduced-motion user preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ All options with their default values:
   headingSelector: 'h1, h2, [role=heading]',
   announcementTemplate: 'Navigated to: {title}',
   urlTemplate: 'New page at {url}',
-  reduceMotion: false
+  respectReducedMotion: false
 }
 ```
 
@@ -109,7 +109,7 @@ How to announce the new page url.
 
 Only used as fallback if neither a title tag nor a heading were found.
 
-### reduceMotion
+### respectReducedMotion
 
 Whether to respects users' preference for reduced motion.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ All options with their default values:
   contentSelector: 'main',
   headingSelector: 'h1, h2, [role=heading]',
   announcementTemplate: 'Navigated to: {title}',
-  urlTemplate: 'New page at {url}'
+  urlTemplate: 'New page at {url}',
+  reduceMotion: false
 }
 ```
 
@@ -107,3 +108,11 @@ How to announce the new page title.
 How to announce the new page url.
 
 Only used as fallback if neither a title tag nor a heading were found.
+
+### reduceMotion
+
+Whether to respects users' preference for reduced motion.
+
+Disable animated page transitions and animated scrolling if a user has enabled a
+setting on their device to minimize the amount of non-essential motion. Learn more about
+[prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,11 +107,15 @@ export default class SwupA11yPlugin extends Plugin {
 	}
 
 	disableTransitionAnimations(visit: Visit) {
-		visit.animation.animate  = false;
+		visit.animation.animate = this.shouldAnimate();
 	}
 
 	disableScrollAnimations(visit: Visit) {
 		// @ts-ignore: animate property is not defined unless Scroll Plugin installed
-		visit.scroll.animate  = false;
+		visit.scroll.animate = this.shouldAnimate();
+	}
+
+	shouldAnimate(): boolean {
+		return !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ type Options = {
 	/** How to announce the new page url. Used as fallback if no heading was found. */
 	urlTemplate: string;
 	/** Whether to skip animations for users that prefer reduced motion. */
-	reduceMotion: boolean;
+	respectReducedMotion: boolean;
 };
 
 export default class SwupA11yPlugin extends Plugin {
@@ -27,7 +27,7 @@ export default class SwupA11yPlugin extends Plugin {
 		headingSelector: 'h1, h2, [role=heading]',
 		announcementTemplate: 'Navigated to: {title}',
 		urlTemplate: 'New page at {url}',
-		reduceMotion: false
+		respectReducedMotion: false
 	};
 
 	options: Options;
@@ -48,8 +48,8 @@ export default class SwupA11yPlugin extends Plugin {
 		// Announce new page after content is replaced
 		this.on('content:replace', this.announceVisit);
 
-		// Disable transition and scroll animations
-		if (this.options.reduceMotion) {
+		// Disable transition and scroll animations if user prefers reduced motion
+		if (this.options.respectReducedMotion) {
 			this.before('visit:start', this.disableTransitionAnimations);
 			this.before('visit:start', this.disableScrollAnimations);
 			this.before('link:self', this.disableScrollAnimations);


### PR DESCRIPTION
**Description**

- Add setting `reduceMotion` that disables animated page transitions & animated scrolling
- Uses the [@prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query
- Will work with Scroll Plugin once [this feature](https://github.com/swup/scroll-plugin/pull/65) is merged
- Will work with swup core out of the box as scrolling isn't animated there anyway

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required

**Additional information**

Closes #6 
