### PR TITLE
Respect existing animation state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,12 +107,12 @@ export default class SwupA11yPlugin extends Plugin {
 	}
 
 	disableTransitionAnimations(visit: Visit) {
-		visit.animation.animate = this.shouldAnimate();
+		visit.animation.animate = visit.animation.animate && this.shouldAnimate();
 	}
 
 	disableScrollAnimations(visit: Visit) {
 		// @ts-ignore: animate property is not defined unless Scroll Plugin installed
-		visit.scroll.animate = this.shouldAnimate();
+		visit.scroll.animate = visit.scroll.animate && this.shouldAnimate();
 	}
 
 	shouldAnimate(): boolean {


### PR DESCRIPTION
**Description**

- The `respectReducedMotion` currently blindly sets the `animation.animate` flag
- If animations are already disabled, this will incorrectly re-enable them, e.g. on popstate visits
- This PR changes the logic to respect the existing config to keep disabled animations disabled

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~

**Additional information**

Closes #29 