### PR TITLE
Customize announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ All options with their default values:
   headingSelector: 'h1, h2, [role=heading]',
   respectReducedMotion: false,
   announcements: {
-    title: 'Navigated to: {title}',
+    visit: 'Navigated to: {title}',
     url: 'New page at {url}'
   }
 }
@@ -127,10 +127,13 @@ customize this. A visit is announced differently, depending on whether the new p
 not. If found, the main heading or document title is announced. If neither
 is found, the new url will be announced instead:
 
+- **Title found?** Read `announcements.visit`, replacing `{title}` with the new title
+- **No title?** Read `announcements.visit` too, but replacing `{title}` with the content of `announcements.url`
+
 ```js
 {
   announcements: {
-    title: 'Navigated to: {title}',
+    visit: 'Navigated to: {title}',
     url: 'New page at {url}'
   }
 }
@@ -150,19 +153,19 @@ it yourself in the `content:replace` hook.
 {
   announcements: {
     'en-US': {
-      title: 'Navigated to: {title}',
+      visit: 'Navigated to: {title}',
       url: 'New page at {url}'
     },
     'de-DE': {
-      title: 'Navigiert zu: {title}',
+      visit: 'Navigiert zu: {title}',
       url: 'Neue Seite unter {url}'
     },
     'fr-FR': {
-      title: 'Navigué vers : {title}',
+      visit: 'Navigué vers : {title}',
       url: 'Nouvelle page à {url}'
     },
     '*': {
-      title: '{title}',
+      visit: '{title}',
       url: '{url}'
     }
   }
@@ -173,7 +176,7 @@ it yourself in the `content:replace` hook.
 
 The following two options are now grouped in the `announcements` object and deprecated.
 
-- `announcementTemplate`: equivalent to `announcements.title`
+- `announcementTemplate`: equivalent to `announcements.visit`
 - `urlTemplate`: equivalent to `announcements.url`
 
 ## Visit object

--- a/README.md
+++ b/README.md
@@ -122,10 +122,9 @@ setting on their device to minimize the amount of non-essential motion. Learn mo
 
 ### announcements
 
-How the new page is announced. Use the variables `{title}`, `{href}`, `{path}` and `{url}` to
-customize this. A visit is announced differently, depending on whether the new page has a title or
-not. If found, the main heading or document title is announced. If neither
-is found, the new url will be announced instead:
+How the new page is announced. A visit is announced differently depending on whether the new page
+has a title or not. If found, the main heading or document title is announced. If neither is found,
+the new url will be announced instead:
 
 - **Title found?** Read `announcements.visit`, replacing `{title}` with the new title
 - **No title?** Read `announcements.visit` too, but replacing `{title}` with the content of `announcements.url`

--- a/README.md
+++ b/README.md
@@ -174,21 +174,20 @@ behavior on the fly.
   from: { ... },
   to: { ... },
   a11y: {
-    announcement: 'Navigated to: About',
+    announce: 'Navigated to: About',
     focus: 'main'
   }
 }
 ```
 
-### visit.a11y.announcement
+### visit.a11y.announce
 
 The text to announce after the new page was loaded. This is the final text after choosing the
 correct language from the [announcements](#announcements) option and filling in any placeholders.
-Modify to read a custom announcement.
+Modify it to read a custom announcement.
 
 Since the text can only be populated once the new page was fetched and its contents are available,
-so the only practical place to inspect or overwrite this would be right before the
-`content:announce` hook:
+the only place to inspect or modify this would be right before the `content:announce` hook.
 
 ```js
 swup.hooks.before('content:announce', (visit) => {

--- a/README.md
+++ b/README.md
@@ -53,7 +53,17 @@ See the options below for customizing what elements to look for.
 </main>
 ```
 
-If you want the announcement to be different from the text content, use `aria-label`:
+## Announcements
+
+The plugin will announce the new page to screen readers after navigating to it. It will look for the
+following and announce the first one found:
+
+- Main heading label: `<h1 aria-label="About"></h1>`
+- Main heading content: `<h1>About</h1>`
+- Document title: `<title>About</title>`
+- Page URL: `/about/`
+
+The easiest way to announce a page title differing from the main heading is using `aria-label`:
 
 ```html
 <h1 aria-label="Homepage">Project Title</h1> <!-- will announce 'Homepage' -->
@@ -112,8 +122,10 @@ setting on their device to minimize the amount of non-essential motion. Learn mo
 
 ### announcements
 
-How to announce the new page. If found, the title tag or main heading is announced. In case neither
-is found, the new url will be announced as title instead.
+How the new page is announced. Use the variables `{title}`, `{href}`, `{path}` and `{url}` to
+customize this. A visit is announced differently, depending on whether the new page has a title or
+not. If found, the main heading or document title is announced. If neither
+is found, the new url will be announced instead:
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -140,9 +140,21 @@ selector `string` to select an element, or set it to `false` to not move the foc
 
 ## Hooks
 
-The plugin adds a new hook: `content:focus`. It is run after `content:replace`, when the new
-content is already in the DOM.
+The plugin adds two new hooks: `content:announce` and `content:focus`. Both run directly
+after the internal `content:replace` handler, when the new content is already in the DOM.
+
+### content:announce
+
+Executes the announcement of the new page title.
 
 ```js
-swup.hooks.on('content:focus', () => console.log('Swup has focussed new content'));
+swup.hooks.on('content:announce', () => console.log('New content was announced'));
+```
+
+### content:focus
+
+Executes the focussing of the new main content container.
+
+```js
+swup.hooks.on('content:focus', () => console.log('New content received focus'));
 ```

--- a/README.md
+++ b/README.md
@@ -159,10 +159,10 @@ it yourself in the `content:replace` hook.
 
 #### Deprecated options
 
-The following two announcement templates variables are now grouped in a single `announcements` object.
+The following two options are now grouped in the `announcements` object and deprecated.
 
-- `announcementTemplate`: How to announce the new page.
-- `urlTemplate`: How to announce the new page if neither a title tag nor a heading were found.
+- `announcementTemplate`: equivalent to `announcements.title`
+- `urlTemplate`: equivalent to `announcements.url`
 
 ## Visit object
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ shortcomings for screen reader users. This plugin will improve that:
 
 - **Announce page visits** to screenreaders by reading the new page title
 - **Focus the main content area** after swapping out the content
+- **Skip animations** for users with a preference for reduced motion
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ All options with their default values:
 {
   contentSelector: 'main',
   headingSelector: 'h1, h2, [role=heading]',
-  announcementTemplate: 'Navigated to: {title}',
-  urlTemplate: 'New page at {url}',
-  respectReducedMotion: false
+  respectReducedMotion: false,
+  announcements: {
+    title: 'Navigated to: {title}',
+    url: 'New page at {url}'
+  }
 }
 ```
 
@@ -99,16 +101,6 @@ The selector for finding headings **inside the main content area**.
 
 The first heading's content will be read to screen readers after a new page was loaded.
 
-### announcementTemplate
-
-How to announce the new page title.
-
-### urlTemplate
-
-How to announce the new page url.
-
-Only used as fallback if neither a title tag nor a heading were found.
-
 ### respectReducedMotion
 
 Whether to respects users' preference for reduced motion.
@@ -117,6 +109,65 @@ Disable animated page transitions and animated scrolling if a user has enabled a
 setting on their device to minimize the amount of non-essential motion. Learn more about
 [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).
 
+### announcements
+
+How to announce the new page. If found, the title tag or main heading is announced. In case neither
+is found, the new url will be announced as title instead.
+
+```js
+{
+  announcements: {
+    title: 'Navigated to: {title}',
+    url: 'New page at {url}'
+  }
+}
+```
+
+#### Translations
+
+For multi-language sites, pass in a nested object keyed by locale. The locale must match the
+`html` element's [lang](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/lang) attribute
+exactly. Use an asterisk `*` to declare fallback translations.
+
+> **Note**: Swup will not update the lang attribute on its own. For that, you can either install the
+[Head Plugin](https://swup.js.org/plugins/head-plugin/) to do it automatically, or you can do update
+it yourself in the `content:replace` hook.
+
+```js
+{
+  announcements: {
+    'en-US': {
+      title: 'Navigated to: {title}',
+      url: 'New page at {url}'
+    },
+    'de-DE': {
+      title: 'Navigiert zu: {title}',
+      url: 'Neue Seite unter {url}'
+    },
+    'fr-FR': {
+      title: 'Navigué vers : {title}',
+      url: 'Nouvelle page à {url}'
+    },
+    '*': {
+      title: '{title}',
+      url: '{url}'
+    }
+  }
+}
+```
+
+### Deprecated options
+
+The following two announcement templates are now grouped in a single `announcements` object.
+
+#### announcementTemplate
+
+How to announce the new page.
+
+#### urlTemplate
+
+How to announce the new page if neither a title tag nor a heading were found.
+
 ## Visit object
 
 The plugin extends the visit object with a new `a11y` key that can be used to customize the
@@ -124,13 +175,22 @@ behavior on the fly.
 
 ```js
 {
-  from: {},
-  to: {},
+  from: { ... },
+  to: { ... },
   a11y: {
+    announcement: 'Navigated to: About',
     focus: 'main'
   }
 }
 ```
+
+### visit.a11y.announcement
+
+The text to announce after the new page was loaded. This is the final text after choosing the
+correct language from the [announcements](#announcements) option and filling in any placeholders.
+Note that this can only be populated once the new page was fetched and its contents are available,
+so the **only** practical place to inspect or overwrite this would be right before the
+`content:announce` hook.
 
 ### visit.a11y.focus
 

--- a/README.md
+++ b/README.md
@@ -156,17 +156,12 @@ it yourself in the `content:replace` hook.
 }
 ```
 
-### Deprecated options
+#### Deprecated options
 
-The following two announcement templates are now grouped in a single `announcements` object.
+The following two announcement templates variables are now grouped in a single `announcements` object.
 
-#### announcementTemplate
-
-How to announce the new page.
-
-#### urlTemplate
-
-How to announce the new page if neither a title tag nor a heading were found.
+- `announcementTemplate`: How to announce the new page.
+- `urlTemplate`: How to announce the new page if neither a title tag nor a heading were found.
 
 ## Visit object
 

--- a/README.md
+++ b/README.md
@@ -183,9 +183,17 @@ behavior on the fly.
 
 The text to announce after the new page was loaded. This is the final text after choosing the
 correct language from the [announcements](#announcements) option and filling in any placeholders.
-Note that this can only be populated once the new page was fetched and its contents are available,
-so the **only** practical place to inspect or overwrite this would be right before the
-`content:announce` hook.
+Modify to read a custom announcement.
+
+Since the text can only be populated once the new page was fetched and its contents are available,
+so the only practical place to inspect or overwrite this would be right before the
+`content:announce` hook:
+
+```js
+swup.hooks.before('content:announce', (visit) => {
+  visit.a11y.announce = 'New page loaded';
+});
+```
 
 ### visit.a11y.focus
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ export default class SwupA11yPlugin extends Plugin {
 	parseTemplate(str: string, replacements: Record<string, string>): string {
 		return Object.keys(replacements).reduce((str, key) => {
 			return str.replace(`{${key}}`, replacements[key] || '');
-		}, str);
+		}, str || '');
 	}
 
 	handleNewPageContent() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Visit, nextTick } from 'swup';
+import { Location, Visit, nextTick } from 'swup';
 import Plugin from '@swup/plugin';
 import OnDemandLiveRegion from 'on-demand-live-region';
 
@@ -137,9 +137,9 @@ export default class SwupA11yPlugin extends Plugin {
 		if (typeof visit.a11y.announce !== 'undefined') return;
 
 		const { contentSelector, headingSelector, announcements } = this.options;
-
-		const url =  window.location.pathname;
+		const { href, url, pathname: path } = Location.fromUrl(window.location.href);
 		const lang = document.documentElement.lang || '*';
+
 		// @ts-expect-error: indexing is messy
 		const templates: Announcements = announcements[lang] || announcements['*'] || announcements;
 		if (typeof templates !== 'object') return;
@@ -147,10 +147,10 @@ export default class SwupA11yPlugin extends Plugin {
 		// Look for first heading in content container
 		const heading = document.querySelector(`${contentSelector} ${headingSelector}`);
 		// Get page title from aria attribute or text content
-		let title = heading?.getAttribute('aria-label') || heading?.textContent || document.title;
-		// Fall back to url if no title was found
-		title = title || this.parseTemplate(templates.url, { url });
-		// Replace {title} and {url} variables in template
+		let title = heading?.getAttribute('aria-label') || heading?.textContent;
+		// Fall back to document title, then url if no title was found
+		title = title || document.title || this.parseTemplate(templates.url, { href, url, path });
+		// Replace {variables} in template
 		const announcement = this.parseTemplate(templates.visit, { title, href, url, path });
 
 		visit.a11y.announce = announcement;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,9 @@ declare module 'swup' {
 
 /** Templates for announcements of the new page content. */
 type Announcements = {
-	/** How to announce the new page title. */
-	title: string;
-	/** How to announce the new page url. Used as fallback if no heading was found. */
+	/** How to announce the new page. */
+	visit: string;
+	/** How to read a page url. Used as fallback if no heading was found. */
 	url: string;
 };
 
@@ -47,9 +47,9 @@ type Options = {
 	/** How to announce the new page title and url. */
 	announcements: Announcements | AnnouncementTranslations;
 
-	/** How to announce the new page title. @deprecated Use the `announcements` option.  */
+	/** How to announce the new page. @deprecated Use the `announcements` option.  */
 	announcementTemplate?: string;
-	/** How to announce the new page url. @deprecated Use the `announcements` option. */
+	/** How to announce a url. @deprecated Use the `announcements` option. */
 	urlTemplate?: string;
 };
 
@@ -63,7 +63,7 @@ export default class SwupA11yPlugin extends Plugin {
 		headingSelector: 'h1, h2, [role=heading]',
 		respectReducedMotion: false,
 		announcements: {
-			title: 'Navigated to: {title}',
+			visit: 'Navigated to: {title}',
 			url: 'New page at {url}'
 		}
 	};
@@ -78,7 +78,7 @@ export default class SwupA11yPlugin extends Plugin {
 		// Merge deprecated announcement templates into new structure
 		options.announcements = {
 			...this.defaults.announcements,
-			title: options.announcementTemplate ?? this.defaults.announcements.title,
+			visit: options.announcementTemplate ?? this.defaults.announcements.visit,
 			url: options.urlTemplate ?? this.defaults.announcements.url,
 			...options.announcements,
 		};
@@ -151,7 +151,7 @@ export default class SwupA11yPlugin extends Plugin {
 		// Fall back to url if no title was found
 		title = title || this.parseTemplate(templates.url, { url });
 		// Replace {title} and {url} variables in template
-		const announcement = this.parseTemplate(templates.title, { title, url });
+		const announcement = this.parseTemplate(templates.visit, { title, href, url, path });
 
 		visit.a11y.announce = announcement;
 	}


### PR DESCRIPTION
**Description**

- Add `visit.a11y.announce` key
- Create `content:announce` hook
- Group announcement templates in `announcements` option
- Allow setting announcement templates by language
- Tested in local playground

**Announcement templates**

Templates are now grouped. The old options are marked as deprecated, but will still be used if present.

```diff
new SwupA11yPlugin({
-   announcementTemplate: 'Navigiert zu: {title}',
-   urlTemplate: 'Neue Seite unter {url}',
+   announcements: {
+     visit: 'Navigiert zu: {title}',
+     url: 'Neue Seite unter {url}'
+   }
})
```

**Multi-language announcements**

Keying the announcements by language will try to match the html element's `lang` attribute. Fallbacks are keyed by `*`. Added a readme note that Head Plugin is required for the lang attribute to update.

```js
new SwupA11yPlugin({
  announcements: {
    'en': {
      visit: 'Navigated to: {title}',
      url: 'New page at {url}'
    },
    'fr': {
      visit: 'Navigué vers : {title}',
      url: 'Nouvelle page à {url}'
    },
    'es': {
      visit: 'Navigado a: {titre}',
      url: 'Nueva pagina en {url}'
    },
    '*': {
      visit: '{title}',
      url: '{url}'
    }
  }
})
```

**Custom announcements**

Hooking before `content:announce` allows setting a custom string to be read:

```js
swup.hooks.before('content:announce', (visit) => {
  visit.a11y.announce = 'New page loaded, but keeping title to myself'
})
```

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required

**Additional information**

Closes #27 