### PR TITLE
Add option to focus `[autofocus]` elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ All options with their default values:
   contentSelector: 'main',
   headingSelector: 'h1, h2, [role=heading]',
   respectReducedMotion: false,
+  autofocus: false,
   announcements: {
     visit: 'Navigated to: {title}',
     url: 'New page at {url}'
@@ -119,6 +120,15 @@ Whether to respects users' preference for reduced motion.
 Disable animated page transitions and animated scrolling if a user has enabled a
 setting on their device to minimize the amount of non-essential motion. Learn more about
 [prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).
+
+### autofocus
+
+Whether to focus elements with an `autofocus` attribute after navigation.
+
+Make sure to use this wisely. Automatically focussing elements can be useful to draw attention to
+inputs, but it comes with a list of drawbacks on its own, especially for screen-reading technology.
+See [Autofocus accessibility considerations](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus#accessibility_considerations)
+for details.
 
 ### announcements
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,8 @@ type Options = {
 	respectReducedMotion: boolean;
 	/** How to announce the new page title and url. */
 	announcements: Announcements | AnnouncementTranslations;
+	/** Whether to focus elements with an [autofocus] attribute after navigation. */
+	autofocus: boolean;
 
 	/** How to announce the new page. @deprecated Use the `announcements` option.  */
 	announcementTemplate?: string;
@@ -68,6 +70,7 @@ export default class SwupA11yPlugin extends Plugin {
 		contentSelector: 'main',
 		headingSelector: 'h1, h2, [role=heading]',
 		respectReducedMotion: false,
+		autofocus: false,
 		announcements: {
 			visit: 'Navigated to: {title}',
 			url: 'New page at {url}'
@@ -121,6 +124,7 @@ export default class SwupA11yPlugin extends Plugin {
 			this.before('link:self', this.disableScrollAnimations);
 			this.before('link:anchor', this.disableScrollAnimations);
 		}
+
 		// Announce something programmatically
 		this.swup.announce = this.announce;
 	}
@@ -198,14 +202,35 @@ export default class SwupA11yPlugin extends Plugin {
 	}
 
 	async focusPageContent(visit: Visit) {
+		// Focus disabled for this visit?
 		if (!visit.a11y.focus) return;
 
+		// Found [autofocus] element?
+		if (this.options.autofocus) {
+			const focusEl = this.getAutofocusElement();
+			if (focusEl) {
+				this.swup.hooks.once('visit:end', (v) => {
+					if (v.id !== visit.id) return;
+					focusEl.focus();
+				});
+				return;
+			}
+		}
+
+		// Otherwise, find content container and focus it
 		const content = document.querySelector<HTMLElement>(visit.a11y.focus);
 		if (content instanceof HTMLElement) {
 			if (this.needsTabindex(content)) {
 				content.setAttribute('tabindex', '-1');
 			}
 			content.focus({ preventScroll: true });
+		}
+	}
+
+	getAutofocusElement(): HTMLElement | undefined {
+		const focusEl = document.querySelector<HTMLElement>('body [autofocus]');
+		if (focusEl && !focusEl.closest('inert, [aria-disabled], [aria-hidden="true"]')) {
+			return focusEl;
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export default class SwupA11yPlugin extends Plugin {
 			...this.defaults.announcements,
 			visit: options.announcementTemplate ?? this.defaults.announcements.visit,
 			url: options.urlTemplate ?? this.defaults.announcements.url,
-			...options.announcements,
+			...options.announcements
 		};
 
 		// Merge default options with user defined options
@@ -199,7 +199,7 @@ export default class SwupA11yPlugin extends Plugin {
 
 	announce = (message: string): void => {
 		this.liveRegion.say(message);
-	}
+	};
 
 	async focusPageContent(visit: Visit) {
 		// Focus disabled for this visit?

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,11 +207,11 @@ export default class SwupA11yPlugin extends Plugin {
 
 		// Found [autofocus] element?
 		if (this.options.autofocus) {
-			const focusEl = this.getAutofocusElement();
-			if (focusEl) {
+			const autofocusEl = this.getAutofocusElement();
+			if (autofocusEl && autofocusEl !== document.activeElement) {
 				this.swup.hooks.once('visit:end', (v) => {
 					if (v.id !== visit.id) return;
-					focusEl.focus();
+					autofocusEl.focus();
 				});
 				return;
 			}


### PR DESCRIPTION
**Description**

- Needed this for a project where the only page content is a single-input newsletter form field 👽
- Optionally focus elements with `[autofocus]` attribute after the visit ends
- Delaying until `visit:end` instead of `content:replace` to avoid issues with scrolling and parallel plugin
- Optional, disabled by default
- Tested in playground

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] The documentation was updated as required
