### PR TITLE
New option and bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [4.6.0] - 2024-01-23
-- Add option to set timeout for announcement
+- Add option to set delay for announcement
 - Fix bug when screen reader sometimes did not pronounce updated text
 
 ## [4.5.0] - 2023-11-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.6.0] - 2024-01-23
+- Add option to set timeout for announcement
+- Fix bug when screen reader sometimes did not pronounce updated text
+
 ## [4.5.0] - 2023-11-21
 
 - Add option to focus `autofocus` elements

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ All options with their default values:
   announcements: {
     visit: 'Navigated to: {title}',
     url: 'New page at {url}'
-  }
+  },
+  timeout: 100,
 }
 ```
 
@@ -180,6 +181,11 @@ it yourself in the `content:replace` hook.
   }
 }
 ```
+### delay
+A delay in milliseconds after which screen reader will pronounce the text.
+0ms delay is not recommended since in that case some screen readers may not pronounce the text
+
+
 
 #### Deprecated options
 
@@ -252,8 +258,12 @@ The plugin adds the following method to the swup instance:
 
 ### announce
 
+```js
+swup.announce?.(message, delay = this.options.delay);
+```
+
 Announce something programmatically. Use this if you are making use of [`options.resolveUrl`](https://swup.js.org/options/#resolve-url) and still want state changes to be announced.
 
 ```js
-swup.announce?.(`Filtered by ${myFilterString}`);
+swup.announce?.(`Filtered by ${myFilterString}`, 50);
 ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ All options with their default values:
     visit: 'Navigated to: {title}',
     url: 'New page at {url}'
   },
-  timeout: 100,
+  delay: 100,
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,8 @@ type Options = {
 	announcements: Announcements | AnnouncementTranslations;
 	/** Whether to focus elements with an [autofocus] attribute after navigation. */
 	autofocus: boolean;
+	/** a delay after which announcement will be pronounced by screen reader. */
+	delay: number;
 
 	/** How to announce the new page. @deprecated Use the `announcements` option.  */
 	announcementTemplate?: string;
@@ -74,7 +76,8 @@ export default class SwupA11yPlugin extends Plugin {
 		announcements: {
 			visit: 'Navigated to: {title}',
 			url: 'New page at {url}'
-		}
+		},
+		delay: 100
 	};
 
 	options: Options;
@@ -193,12 +196,12 @@ export default class SwupA11yPlugin extends Plugin {
 
 	announcePageName(visit: Visit) {
 		if (visit.a11y.announce) {
-			this.liveRegion.say(visit.a11y.announce);
+			this.liveRegion.say(visit.a11y.announce, this.options.delay);
 		}
 	}
 
-	announce = (message: string): void => {
-		this.liveRegion.say(message);
+	announce = (message: string, delay: number = this.options.delay): void => {
+		this.liveRegion.say(message, delay);
 	};
 
 	async focusPageContent(visit: Visit) {


### PR DESCRIPTION
<!--
Thanks for creating this pull request!

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple PRs instead of opening a huge one.
-->

**Description**

- Fixed bug when screen reader sometimes did not pronounce announcement due to 0 timeout (tested on NVDA on windows 11)
- Added new option - delay, that defaults to 100
- Updated `announce` method to include delay parameter

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [ ] New or updated tests are included
- [x] The documentation was updated as required


