### PR TITLE
Read new page title from h1 only

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ For multi-language sites, pass in a nested object keyed by locale. The locale mu
 exactly. Use an asterisk `*` to declare fallback translations.
 
 > **Note**: Swup will not update the lang attribute on its own. For that, you can either install the
-[Head Plugin](https://swup.js.org/plugins/head-plugin/) to do it automatically, or you can do update
-it yourself in the `content:replace` hook.
+> [Head Plugin](https://swup.js.org/plugins/head-plugin/) to do it automatically, or you can do update
+> it yourself in the `content:replace` hook.
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The plugin should work out of the box if you use proper semantic markup for your
 content, i.e. `main` for your content area and `h1` for your headings.
 See the options below for customizing what elements to look for.
 
+<!-- prettier-ignore -->
 ```html
 <header>
   Logo
@@ -69,6 +70,7 @@ following and announce the first one found:
 
 The easiest way to announce a page title differing from the main heading is using `aria-label`:
 
+<!-- prettier-ignore -->
 ```html
 <h1 aria-label="Homepage">Project Title</h1> <!-- will announce 'Homepage' -->
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const swup = new Swup({
 ## Markup
 
 The plugin should work out of the box if you use proper semantic markup for your
-content, i.e. `main` for your content area and `h1` or `h2` for your headings.
+content, i.e. `main` for your content area and `h1` for your headings.
 See the options below for customizing what elements to look for.
 
 ```html
@@ -95,7 +95,7 @@ All options with their default values:
 ```javascript
 {
   contentSelector: 'main',
-  headingSelector: 'h1, h2, [role=heading]',
+  headingSelector: 'h1',
   respectReducedMotion: false,
   autofocus: false,
   announcements: {
@@ -115,7 +115,7 @@ This area will receive focus after a new page was loaded.
 
 The selector for finding headings **inside the main content area**.
 
-The first heading's content will be read to screen readers after a new page was loaded.
+The content of the first found heading will be read to screen readers after a new page was loaded.
 
 ### respectReducedMotion
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,10 +160,16 @@ export default class SwupA11yPlugin extends Plugin {
 
 		// Look for first heading in content container
 		const heading = document.querySelector(`${contentSelector} ${headingSelector}`);
+		if (!heading) {
+			console.warn(`SwupA11yPlugin: No main heading (${headingSelector}) found in content container`);
+		}
+
 		// Get page title from aria attribute or text content
 		let title = heading?.getAttribute('aria-label') || heading?.textContent;
+
 		// Fall back to document title, then url if no title was found
 		title = title || document.title || this.parseTemplate(templates.url, { href, url, path });
+
 		// Replace {variables} in template
 		const announcement = this.parseTemplate(templates.visit, { title, href, url, path });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export default class SwupA11yPlugin extends Plugin {
 
 	defaults: Options = {
 		contentSelector: 'main',
-		headingSelector: 'h1, h2, [role=heading]',
+		headingSelector: 'h1',
 		respectReducedMotion: false,
 		autofocus: false,
 		announcements: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,9 @@ export default class SwupA11yPlugin extends Plugin {
 		// Look for first heading in content container
 		const heading = document.querySelector(`${contentSelector} ${headingSelector}`);
 		if (!heading) {
-			console.warn(`SwupA11yPlugin: No main heading (${headingSelector}) found in content container`);
+			console.warn(
+				`SwupA11yPlugin: No main heading (${headingSelector}) found in content container`
+			);
 		}
 
 		// Get page title from aria attribute or text content


### PR DESCRIPTION
**Description**

I stumbled upon an issue where the current heading selector of `h1, h2, [role=heading]` would wrongly read out a sub-heading `h2` if the page was missing an `h1`. While the original idea was to increase the chances of finding a heading, it actually has the opposite effect and confuses visitors by reading a completely unrelated heading.

I'd suggest only using `h1` for headings to read. If none is found, it will fall back to the `document.title` directly instead of picking a possibly unrelated heading from further down the page.

Doing some comparisons across [various](https://github.com/sveltejs/kit/blob/38294bef6ae347b2153aea9f9f56bed025a0cebd/packages/kit/src/core/sync/write_root.js#L101) [similar](https://github.com/vercel/next.js/blob/canary/packages/next/src/client/route-announcer.tsx#L43) [implementations](https://github.com/withastro/astro/blob/fd18a5dda981c1b13c0a585d174ed2f09a2e9218/packages/astro/src/transitions/router.ts#L56) [in the wild](https://github.com/ember-a11y/a11y-announcer/blob/master/app/initializers/add-announcer-to-router.js#L21), it turns out that all solutions only read from the `h1`. They also all seem to prefer `document.title` to `h1`, but I'd opt for sticking with our preference for `h1`, mainly to avoid reading the site name added to most document titles with every announcement.

**Release cycle**

I'd say this is more of a fix than a feature? But we can also release this with all the other focus and announcement updates as a single feature release.

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required
