### PR TITLE
Enabled `respectReducedMotion` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ All options with their default values:
 ```javascript
 {
   headingSelector: 'h1',
-  respectReducedMotion: false,
+  respectReducedMotion: true,
   autofocus: false,
   announcements: {
     visit: 'Navigated to: {title}',

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export default class SwupA11yPlugin extends Plugin {
 
 	defaults: Options = {
 		headingSelector: 'h1',
-		respectReducedMotion: false,
+		respectReducedMotion: true,
 		autofocus: false,
 		announcements: {
 			visit: 'Navigated to: {title}',


### PR DESCRIPTION
**Description**

- In preparation of a major release, enable `respectReducedMotion` by default
- I just remembered we put this off to avoid the breaking change
- But now is the time ⏰

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [x] The documentation was updated as required