### PR TITLE
Tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,28 @@
+name: Unit tests
+
+on:
+  push:
+    branches: [main, master, next]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  run-tests:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Run tests
+        run: npm run test:unit

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ wiki-wishlist
 *.sublime-workspace
 .editorconfig
 .idea
-dist
-/plugins
-*.tgz
+/dist
+/tests/fixtures/dist
+/tests/reports
+/tests/results

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,10 @@
         "focus-options-polyfill": "^1.5.0"
       },
       "devDependencies": {
-        "@swup/cli": "^5.0.0"
+        "@swup/cli": "^5.0.1",
+        "@types/jsdom": "^21.1.4",
+        "jsdom": "^24.0.0",
+        "vitest": "^1.2.2"
       },
       "peerDependencies": {
         "swup": "^4.0.0"
@@ -1958,6 +1961,374 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2052,6 +2423,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2361,6 +2744,207 @@
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.2.tgz",
+      "integrity": "sha512-ahxSgCkAEk+P/AVO0vYr7DxOD3CwAQrT0Go9BJyGQ9Ef0QxVOfjDZMiF4Y2s3mLyPrjonchIMH/tbWHucJMykQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.2.tgz",
+      "integrity": "sha512-lAarIdxZWbFSHFSDao9+I/F5jDaKyCqAPMq5HqnfpBw8dKDiCaaqM0lq5h1pQTLeIqueeay4PieGR5jGZMWprw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.2.tgz",
+      "integrity": "sha512-SWsr8zEUk82KSqquIMgZEg2GE5mCSfr9sE/thDROkX6pb3QQWPp8Vw8zOq2GyxZ2t0XoSIUlvHDkrf5Gmf7x3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.2.tgz",
+      "integrity": "sha512-o/HAIrQq0jIxJAhgtIvV5FWviYK4WB0WwV91SLUnsliw1lSAoLsmgEEgRWzDguAFeUEUUoIWXiJrPqU7vGiVkA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.2.tgz",
+      "integrity": "sha512-nwlJ65UY9eGq91cBi6VyDfArUJSKOYt5dJQBq8xyLhvS23qO+4Nr/RreibFHjP6t+5ap2ohZrUJcHv5zk5ju/g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.2.tgz",
+      "integrity": "sha512-Pg5TxxO2IVlMj79+c/9G0LREC9SY3HM+pfAwX7zj5/cAuwrbfj2Wv9JbMHIdPCfQpYsI4g9mE+2Bw/3aeSs2rQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.2.tgz",
+      "integrity": "sha512-cAOTjGNm84gc6tS02D1EXtG7tDRsVSDTBVXOLbj31DkwfZwgTPYZ6aafSU7rD/4R2a34JOwlF9fQayuTSkoclA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.2.tgz",
+      "integrity": "sha512-4RyT6v1kXb7C0fn6zV33rvaX05P0zHoNzaXI/5oFHklfKm602j+N4mn2YvoezQViRLPnxP8M1NaY4s/5kXO5cw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.2.tgz",
+      "integrity": "sha512-KNUH6jC/vRGAKSorySTyc/yRYlCwN/5pnMjXylfBniwtJx5O7X17KG/0efj8XM3TZU7raYRXJFFReOzNmL1n1w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.2.tgz",
+      "integrity": "sha512-xPV4y73IBEXToNPa3h5lbgXOi/v0NcvKxU0xejiFw6DtIYQqOTMhZ2DN18/HrrP0PmiL3rGtRG9gz1QE8vFKXQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.2.tgz",
+      "integrity": "sha512-QBhtr07iFGmF9egrPOWyO5wciwgtzKkYPNLVCFZTmr4TWmY0oY2Dm/bmhHjKRwZoGiaKdNcKhFtUMBKvlchH+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.2.tgz",
+      "integrity": "sha512-8zfsQRQGH23O6qazZSFY5jP5gt4cFvRuKTpuBsC1ZnSWxV8ZKQpPqOZIUtdfMOugCcBvFGRa1pDC/tkf19EgBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.2.tgz",
+      "integrity": "sha512-H4s8UjgkPnlChl6JF5empNvFHp77Jx+Wfy2EtmYPe9G22XV+PMuCinZVHurNe8ggtwoaohxARJZbaH/3xjB/FA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.2.tgz",
+      "integrity": "sha512-djqpAjm/i8erWYF0K6UY4kRO3X5+T4TypIqw60Q8MTqSBaQNpNXDhxdjpZ3ikgb+wn99svA7jxcXpiyg9MUsdw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.2.tgz",
+      "integrity": "sha512-teAqzLT0yTYZa8ZP7zhFKEx4cotS8Tkk5XiqNMJhD4CpaWB1BHARE4Qy+RzwnXvSAYv+Q3jAqCVBS+PS+Yee8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -2471,6 +3055,17 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.6",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.6.tgz",
+      "integrity": "sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.12.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.4.tgz",
@@ -2495,6 +3090,123 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.5.0.tgz",
+      "integrity": "sha512-0pzuCI6KYi2SIC3LQezmxujU9RK/vwC1U9R0rLuGlNGcOuDWxqWKu6nUdFsX9tH1WU0SXtAxToOsEjeUn1s3hA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "1.5.0",
+        "@vitest/utils": "1.5.0",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.5.0.tgz",
+      "integrity": "sha512-7HWwdxXP5yDoe7DTpbif9l6ZmDwCzcSIK38kTSIt6CFEpMjX4EpCgT6wUmS0xTXqMI6E/ONmfgRKmaujpabjZQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "1.5.0",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.5.0.tgz",
+      "integrity": "sha512-qpv3fSEuNrhAO3FpH6YYRdaECnnRjg9VxbhdtPwPRnzSfHVXnNzzrpX4cJxqiwgRMo7uRMWDFBlsBq4Cr+rO3A==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.9.tgz",
+      "integrity": "sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.5.0.tgz",
+      "integrity": "sha512-vu6vi6ew5N5MMHJjD5PoakMRKYdmIrNJmyfkhRpQt5d9Ewhw9nZ5Aqynbi3N61bvk9UvZ5UysMT6ayIrZ8GA9w==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.5.0.tgz",
+      "integrity": "sha512-BDU0GNL8MWkRkSRdNFvCUCAVOeHaUlVJ9Tx0TYBZyXaaOTmGtUFObzchCivIBrIwKzvZA7A9sCejVhXM2aY98A==",
+      "dev": true,
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/@vitest/utils/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -2514,6 +3226,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2664,6 +3388,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/astral-regex": {
@@ -2958,6 +3691,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -3049,6 +3791,24 @@
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
+    "node_modules/chai": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3075,6 +3835,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/cheerio": {
@@ -3611,6 +4383,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
+      "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
+      "dev": true,
+      "dependencies": {
+        "rrweb-cssom": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -3621,6 +4405,19 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/data-view-buffer": {
@@ -3689,6 +4486,24 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deepmerge": {
@@ -3770,6 +4585,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dir-glob": {
@@ -4020,6 +4844,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
@@ -4074,6 +4936,68 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -4396,6 +5320,15 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -4422,6 +5355,18 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -4724,6 +5669,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -4736,6 +5693,19 @@
         "entities": "^1.1.1",
         "inherits": "^2.0.1",
         "readable-stream": "^3.1.1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/http-signature": {
@@ -4751,6 +5721,28 @@
       "engines": {
         "node": ">=0.8",
         "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
       }
     },
     "node_modules/hyperlinker": {
@@ -5090,6 +6082,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -5128,6 +6126,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -5332,6 +6342,84 @@
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
+    "node_modules/jsdom": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.0.0.tgz",
+      "integrity": "sha512-UDS2NayCvmXSXVP6mpTj+73JnNQadZlr9N68189xib2tx5Mls7swlTNao26IoHv46BZJFvXygyRtyXd1feAk1A==",
+      "dev": true,
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.7",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.16.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsdom/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -5379,6 +6467,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
+      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -5542,6 +6636,22 @@
       "dev": true,
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+      "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+      "dev": true,
+      "dependencies": {
+        "mlly": "^1.4.2",
+        "pkg-types": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/locate-path": {
@@ -5815,6 +6925,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lru-cache": {
@@ -6122,6 +7241,18 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.6.1.tgz",
+      "integrity": "sha512-vLgaHvaeunuOXHSmEbZ9izxPx3USsk8KCQ8iC+aTlp5sKRSoZvwhHh5L9VbKSaVC6sJDqbyohIS76E2VmHIPAA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.3",
+        "pathe": "^1.1.2",
+        "pkg-types": "^1.0.3",
+        "ufo": "^1.3.2"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -6200,6 +7331,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/nth-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -6217,6 +7375,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
+      "dev": true
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
@@ -6439,6 +7603,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/password-prompt": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.3.tgz",
@@ -6521,6 +7709,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -6567,6 +7770,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+      "integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.2.0",
+        "mlly": "^1.2.0",
+        "pathe": "^1.1.0"
       }
     },
     "node_modules/playwright": {
@@ -7194,6 +8408,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/promise.series": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/promise.series/-/promise.series-0.2.0.tgz",
@@ -7227,6 +8467,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7255,6 +8501,12 @@
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -7421,6 +8673,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -7732,6 +8990,12 @@
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
       "dev": true
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7833,6 +9097,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/seenreq": {
       "version": "3.0.0",
@@ -7962,6 +9238,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -8080,6 +9362,18 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
+      "dev": true
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
       "dev": true
     },
     "node_modules/string_decoder": {
@@ -8225,6 +9519,36 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.0.tgz",
+      "integrity": "sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.0.tgz",
+      "integrity": "sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==",
+      "dev": true
     },
     "node_modules/style-inject": {
       "version": "0.3.0",
@@ -8436,6 +9760,12 @@
         "path-to-regexp": "^6.2.1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "node_modules/terser": {
       "version": "5.30.3",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.3.tgz",
@@ -8470,6 +9800,30 @@
         "globrex": "^0.1.2"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.7.0.tgz",
+      "integrity": "sha512-Qgayeb106x2o4hNzNjsZEfFziw8IbKqtbXBjVh7VIZfBxfD5M4gWtpyx5+YTae2gJ6Y6Dz/KLepiv16RFeQWNA==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.3.tgz",
+      "integrity": "sha512-Ud7uepAklqRH1bvwy22ynrliC7Dljz7Tm8M/0RBUW+YRa4YHhZ6e4PpgE+fu1zr/WqB1kbeuVrdfeuyIBpy4tw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -8502,6 +9856,18 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-node": {
@@ -8570,6 +9936,15 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
@@ -8687,6 +10062,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.3.tgz",
+      "integrity": "sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==",
+      "dev": true
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -8796,6 +10177,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8830,6 +10221,281 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.8.tgz",
+      "integrity": "sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.20.1",
+        "postcss": "^8.4.38",
+        "rollup": "^4.13.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.5.0.tgz",
+      "integrity": "sha512-tV8h6gMj6vPzVCa7l+VGq9lwoJjW8Y79vst8QZZGiuRAfijU+EEWuc0kFpmndQrWhMMhet1jdSF+40KSZUqIIw==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/rollup": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.2.tgz",
+      "integrity": "sha512-WkeoTWvuBoFjFAhsEOHKRoZ3r9GfTyhh7Vff1zwebEFLEFjT1lG3784xEgKiTa7E+e70vsC81roVL2MP4tgEEQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.14.2",
+        "@rollup/rollup-android-arm64": "4.14.2",
+        "@rollup/rollup-darwin-arm64": "4.14.2",
+        "@rollup/rollup-darwin-x64": "4.14.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.14.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.14.2",
+        "@rollup/rollup-linux-arm64-musl": "4.14.2",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.14.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.14.2",
+        "@rollup/rollup-linux-x64-gnu": "4.14.2",
+        "@rollup/rollup-linux-x64-musl": "4.14.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.14.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.14.2",
+        "@rollup/rollup-win32-x64-msvc": "4.14.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.5.0.tgz",
+      "integrity": "sha512-d8UKgR0m2kjdxDWX6911uwxout6GHS0XaGH1cksSIVVG8kRlE7G7aBw7myKQCvDI5dT4j7ZMa+l706BIORMDLw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "1.5.0",
+        "@vitest/runner": "1.5.0",
+        "@vitest/snapshot": "1.5.0",
+        "@vitest/spy": "1.5.0",
+        "@vitest/utils": "1.5.0",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.5.0",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.5.0",
+        "@vitest/ui": "1.5.0",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.9.tgz",
+      "integrity": "sha512-S1+hd+dIrC8EZqKyT9DstTH/0Z+f76kmmvZnkfQVmOpDEF9iVgdYif3Q/pIWHmCoo59bQVGW0kVL3e2nl+9+Sw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -8880,6 +10546,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {
@@ -8941,6 +10623,42 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/ws": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8999,6 +10717,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@swup/cli": "^5.0.1",
         "@types/jsdom": "^21.1.4",
         "jsdom": "^24.0.0",
+        "mock-match-media": "^0.4.3",
         "vitest": "^1.2.2"
       },
       "peerDependencies": {
@@ -4249,6 +4250,12 @@
         "postcss": "^8.0.9"
       }
     },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
+      "dev": true
+    },
     "node_modules/css-select": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -7251,6 +7258,15 @@
         "pathe": "^1.1.2",
         "pkg-types": "^1.0.3",
         "ufo": "^1.3.2"
+      }
+    },
+    "node_modules/mock-match-media": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/mock-match-media/-/mock-match-media-0.4.3.tgz",
+      "integrity": "sha512-8nqA2fh5mmgtZEN6sDPlEbLqlqEkF8kCIL17ozbWNHLxnLPF/cli0B6sLffOyfqSBBuVWprEKjYyN8tPXMYmVA==",
+      "dev": true,
+      "dependencies": {
+        "css-mediaquery": "^0.1.2"
       }
     },
     "node_modules/mri": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@swup/cli": "^5.0.1",
     "@types/jsdom": "^21.1.4",
     "jsdom": "^24.0.0",
+    "mock-match-media": "^0.4.3",
     "vitest": "^1.2.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "dev": "swup package:dev",
     "lint": "swup package:lint",
     "format": "swup package:format",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "npm run test:unit",
+    "test:unit": "vitest run --config ./tests/config/vitest.config.ts",
+    "test:unit:watch": "vitest --config ./tests/config/vitest.config.ts"
   },
   "author": {
     "name": "Philipp Daun",
@@ -57,7 +60,10 @@
     "focus-options-polyfill": "^1.5.0"
   },
   "devDependencies": {
-    "@swup/cli": "^5.0.0"
+    "@swup/cli": "^5.0.1",
+    "@types/jsdom": "^21.1.4",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.2.2"
   },
   "peerDependencies": {
     "swup": "^4.0.0"

--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -5,7 +5,7 @@ import { createElement, parseTemplate } from './util.js';
 export class Announcer {
 	id: string = 'swup-announcer';
 	style: string = `position:absolute;top:0;left:0;clip:rect(0 0 0 0);clip-path:inset(50%);overflow:hidden;white-space:nowrap;word-wrap:normal;width:1px;height:1px;`;
-	region: Element;
+	region: HTMLElement;
 
 	constructor() {
 		this.region = this.getRegion() ?? this.createRegion();
@@ -15,7 +15,7 @@ export class Announcer {
 		return document.getElementById(this.id);
 	}
 
-	createRegion(): Element {
+	createRegion(): HTMLElement {
 		const liveRegion = createElement(
 			`<p aria-live="assertive" aria-atomic="true" id="${this.id}" style="${this.style}"></p>`
 		);

--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -23,16 +23,20 @@ export class Announcer {
 		return liveRegion;
 	}
 
-	announce(message: string, delay: number = 0) {
-		setTimeout(() => {
-			// // Fix screen readers not announcing the same message twice
-			if (this.region.textContent === message) {
-				message = `${message}.`;
-			}
-			// Clear before announcing
-			this.region.textContent = '';
-			this.region.textContent = message;
-		}, delay);
+	announce(message: string, delay: number = 0): Promise<void> {
+		return new Promise((resolve) => {
+			setTimeout(() => {
+				// // Fix screen readers not announcing the same message twice
+				if (this.region.textContent === message) {
+					message = `${message}.`;
+				}
+				// Clear before announcing
+				this.region.textContent = '';
+				this.region.textContent = message;
+
+				resolve();
+			}, delay);
+		});
 	}
 }
 

--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -26,7 +26,7 @@ export class Announcer {
 	announce(message: string, delay: number = 0): Promise<void> {
 		return new Promise((resolve) => {
 			setTimeout(() => {
-				// // Fix screen readers not announcing the same message twice
+				// Make each message unique to allow reading identical page titles twice in a row
 				if (this.region.textContent === message) {
 					message = `${message}.`;
 				}

--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -43,8 +43,8 @@ export class Announcer {
 type PageAnnouncementOptions = Pick<Options, 'headingSelector' | 'announcements'>;
 
 export function getPageAnnouncement({
-	headingSelector,
-	announcements
+	headingSelector = 'h1',
+	announcements = {}
 }: PageAnnouncementOptions): string | undefined {
 	const lang = document.documentElement.lang || '*';
 	const { href, url, pathname: path } = Location.fromUrl(window.location.href);

--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -40,7 +40,7 @@ export class Announcer {
 	}
 }
 
-type PageAnnouncementOptions = Pick<Options, 'headingSelector' | 'announcements'>;
+export type PageAnnouncementOptions = Pick<Options, 'headingSelector' | 'announcements'>;
 
 export function getPageAnnouncement({
 	headingSelector = 'h1',

--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -49,7 +49,10 @@ export function getPageAnnouncement({
 	const lang = document.documentElement.lang || '*';
 	const { href, url, pathname: path } = Location.fromUrl(window.location.href);
 
-	const templates = (announcements as AnnouncementTranslations)[lang] || announcements;
+	const templates =
+		(announcements as AnnouncementTranslations)[lang] ??
+		(announcements as AnnouncementTranslations)['*'] ??
+		announcements;
 	if (typeof templates !== 'object') return;
 
 	// Look for first heading on page

--- a/src/focus.ts
+++ b/src/focus.ts
@@ -34,7 +34,7 @@ export function focusAutofocusElement(): boolean {
 
 export function getAutofocusElement(): HTMLElement | undefined {
 	const focusEl = document.querySelector<HTMLElement>('body [autofocus]');
-	if (focusEl && !focusEl.closest('inert, [aria-disabled], [aria-hidden="true"]')) {
+	if (focusEl && !focusEl.closest('[inert], [aria-disabled], [aria-hidden="true"]')) {
 		return focusEl;
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,8 +122,8 @@ export default class SwupA11yPlugin extends Plugin {
 		this.swup.announce = undefined;
 	}
 
-	announce(message: string): void {
-		this.announcer.announce(message);
+	async announce(message: string): Promise<void> {
+		await this.announcer.announce(message);
 	}
 
 	markAsBusy() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,12 +107,9 @@ export default class SwupA11yPlugin extends Plugin {
 		this.on('scroll:anchor', this.handleAnchorScroll);
 
 		// Disable transition and scroll animations if user prefers reduced motion
-		if (this.options.respectReducedMotion) {
-			this.before('visit:start', this.disableTransitionAnimations);
-			this.before('visit:start', this.disableScrollAnimations);
-			this.before('link:self', this.disableScrollAnimations);
-			this.before('link:anchor', this.disableScrollAnimations);
-		}
+		this.before('visit:start', this.disableAnimations);
+		this.before('link:self', this.disableAnimations);
+		this.before('link:anchor', this.disableAnimations);
 
 		// Announce something programmatically
 		this.swup.announce = this.announce.bind(this);
@@ -181,13 +178,12 @@ export default class SwupA11yPlugin extends Plugin {
 		return getPageAnnouncement({ headingSelector, announcements });
 	}
 
-	disableTransitionAnimations(visit: Visit) {
-		visit.animation.animate = visit.animation.animate && this.shouldAnimate();
-	}
-
-	disableScrollAnimations(visit: Visit) {
-		// @ts-expect-error: animate property is not defined unless Scroll Plugin installed
-		visit.scroll.animate = visit.scroll.animate && this.shouldAnimate();
+	disableAnimations(visit: Visit) {
+		if (this.options.respectReducedMotion && !this.shouldAnimate()) {
+			visit.animation.animate = false;
+			// @ts-expect-error: animate is undefined unless Scroll Plugin installed
+			visit.scroll.animate = false;
+		}
 	}
 
 	shouldAnimate(): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,8 +71,20 @@ export default class SwupA11yPlugin extends Plugin {
 
 	options: Options;
 
+	/**
+	 * The announcer instance for reading new page content.
+	 */
 	announcer: Announcer;
 
+	/**
+	 * The delay before announcing new page content.
+	 * Why 100ms? see research at https://github.com/swup/a11y-plugin/pull/50
+	 */
+	announcementDelay: number = 100;
+
+	/**
+	 * The selector for the main content area of the page, to focus after navigation.
+	 */
 	rootSelector: string = 'body';
 
 	constructor(options: Partial<Options> = {}) {
@@ -145,17 +157,14 @@ export default class SwupA11yPlugin extends Plugin {
 				visit.a11y.announce = this.getPageAnnouncement();
 			}
 
-			// Announcement disabled for this visit?
 			if (!visit.a11y.announce) return;
 
-			// Why the 100ms delay? see research at https://github.com/swup/a11y-plugin/pull/50
-			this.announcer.announce(visit.a11y.announce, 100);
+			this.announcer.announce(visit.a11y.announce, this.announcementDelay);
 		});
 	}
 
 	focusContent(visit: Visit) {
 		this.swup.hooks.callSync('content:focus', visit, undefined, (visit) => {
-			// Focus disabled for this visit?
 			if (!visit.a11y.focus) return;
 
 			// Found and focused [autofocus] element? Return early

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import 'focus-options-polyfill';
 
 import { Announcer, getPageAnnouncement } from './announcements.js';
 import { focusAutofocusElement, focusElement } from './focus.js';
+import { prefersReducedMotion } from './util.js';
 
 export interface VisitA11y {
 	/** How to announce the new content after it inserted */
@@ -188,14 +189,10 @@ export default class SwupA11yPlugin extends Plugin {
 	}
 
 	disableAnimations(visit: Visit) {
-		if (this.options.respectReducedMotion && !this.shouldAnimate()) {
+		if (this.options.respectReducedMotion && prefersReducedMotion()) {
 			visit.animation.animate = false;
 			// @ts-expect-error: animate is undefined unless Scroll Plugin installed
 			visit.scroll.animate = false;
 		}
-	}
-
-	shouldAnimate(): boolean {
-		return !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 	}
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
-export function createElement(html: string): Element {
+export function createElement(html: string): HTMLElement {
 	const template = document.createElement('template');
 	template.innerHTML = html;
-	return template.content.children[0];
+	return template.content.children[0] as HTMLElement;
 }
 
 export function parseTemplate(str: string, replacements: Record<string, string>): string {

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,3 +9,7 @@ export function parseTemplate(str: string, replacements: Record<string, string>)
 		return str.replace(`{${key}}`, replacements[key] || '');
 	}, str || '');
 }
+
+export function prefersReducedMotion(): boolean {
+	return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}

--- a/tests/config/vitest.config.ts
+++ b/tests/config/vitest.config.ts
@@ -1,0 +1,21 @@
+/**
+ * Vitest config file
+ * @see https://vitest.dev/config/
+ */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'jsdom',
+		environmentOptions: {
+			jsdom: {
+				console: true,
+				resources: 'usable'
+			}
+		},
+		include: ['tests/unit/**/*.test.ts'],
+		setupFiles: ['tests/config/vitest.setup.ts'],
+		testTimeout: 1000
+	}
+});

--- a/tests/config/vitest.setup.ts
+++ b/tests/config/vitest.setup.ts
@@ -1,0 +1,13 @@
+import { vi } from 'vitest';
+
+/**
+ * Allow spying on the console
+ */
+// vi.spyOn(console, 'log');
+// vi.spyOn(console, 'warn');
+// vi.spyOn(console, 'error');
+
+// Stub browser functions for vitest
+// console.log = vi.fn();
+// console.warn = vi.fn();
+// console.error = vi.fn();

--- a/tests/config/vitest.setup.ts
+++ b/tests/config/vitest.setup.ts
@@ -1,17 +1,10 @@
 import { afterEach, vi } from 'vitest';
+import { matchMedia, cleanupMedia } from 'mock-match-media';
 
-/**
- * Allow spying on the console
- */
-// vi.spyOn(console, 'log');
-// vi.spyOn(console, 'warn');
-// vi.spyOn(console, 'error');
-
-// Stub browser functions for vitest
-// console.log = vi.fn();
-// console.warn = vi.fn();
-// console.error = vi.fn();
+window.matchMedia = matchMedia;
 
 afterEach(() => {
-  document.body.innerHTML = '';
+	document.body.innerHTML = '';
+	vi.clearAllMocks();
+	cleanupMedia();
 });

--- a/tests/config/vitest.setup.ts
+++ b/tests/config/vitest.setup.ts
@@ -1,4 +1,4 @@
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 
 /**
  * Allow spying on the console
@@ -11,3 +11,7 @@ import { vi } from 'vitest';
 // console.log = vi.fn();
 // console.warn = vi.fn();
 // console.error = vi.fn();
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { Announcer, getPageAnnouncement } from '../../src/announcements.js';
+
+describe('announcer', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	describe('live region', () => {
+		it('creates an empty live region', () => {
+			const announcer = new Announcer();
+			const region = announcer.region;
+
+			expect(region).toBeInstanceOf(HTMLElement);
+			expect(region.id).toBe('swup-announcer');
+			expect(region.getAttribute('aria-live')).toBe('assertive');
+			expect(region.parentNode).toBe(document.body);
+			expect(region.textContent).toBe('');
+		});
+
+		it('creates an invisible live region', () => {
+			const announcer = new Announcer();
+			const region = announcer.region;
+
+			expect(region.style.position).toBe('absolute');
+			expect(region.style.top).toBe('0px');
+			expect(region.style.left).toBe('0px');
+		});
+
+		it('reuses existing live region', () => {
+			const existingRegion = document.createElement('div');
+			existingRegion.id = 'swup-announcer';
+			document.body.appendChild(existingRegion);
+
+			const announcer = new Announcer();
+			expect(announcer.region).toBe(existingRegion);
+		});
+	});
+
+	describe('announce', () => {
+		it('returns a promise',  () => {
+			const announcer = new Announcer();
+			expect(announcer.announce('Hello')).toBeInstanceOf(Promise);
+		});
+
+		it('adds the announcement to the live region', async () => {
+			const announcer = new Announcer();
+			await announcer.announce('Hello');
+			expect(announcer.region.textContent).toBe('Hello');
+		});
+
+		it('modifies the announcement to allow duplicate messages', async () => {
+			const announcer = new Announcer();
+			const region = announcer.region;
+
+			await announcer.announce('Hello');
+			expect(region.textContent).toBe('Hello');
+			await announcer.announce('Hello');
+			expect(region.textContent).toBe('Hello.');
+			await announcer.announce('Hello');
+			expect(region.textContent).toBe('Hello');
+		});
+	});
+});

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -1,5 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { Announcer, getPageAnnouncement } from '../../src/announcements.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	Announcer,
+	PageAnnouncementOptions,
+	getPageAnnouncement
+} from '../../src/announcements.js';
 
 describe('announcer', () => {
 	afterEach(() => {
@@ -84,7 +88,7 @@ describe('getPageAnnouncement', () => {
 		}
 	};
 
-	const defaults = { headingSelector: 'h1', announcements };
+	const defaults: PageAnnouncementOptions = { headingSelector: 'h1', announcements };
 
 	describe('headings', () => {
 		it('gets heading title', () => {
@@ -125,6 +129,34 @@ describe('getPageAnnouncement', () => {
 			document.title = '';
 			const announcement = getPageAnnouncement(defaults);
 			expect(announcement).toBe('Loaded page at /');
+		});
+	});
+
+	describe('multi-language', () => {
+		const multiLangDefaults: PageAnnouncementOptions = {
+			headingSelector: 'h1',
+			announcements: multiLangAnnouncements
+		};
+
+		it('uses the current language for announcements', () => {
+			document.documentElement.lang = 'de';
+			document.body.innerHTML = '<h1>Page</h1>';
+			const announcement = getPageAnnouncement(multiLangDefaults);
+			expect(announcement).toBe('Page geladen');
+		});
+
+		it('falls back to default language', () => {
+			document.documentElement.lang = 'it';
+			document.body.innerHTML = '<h1>Page</h1>';
+			const announcement = getPageAnnouncement(multiLangDefaults);
+			expect(announcement).toBe('Page');
+		});
+
+		it('matches the language strictly', () => {
+			document.documentElement.lang = 'de-DE';
+			document.body.innerHTML = '<h1>Page</h1>';
+			const announcement = getPageAnnouncement(multiLangDefaults);
+			expect(announcement).toBe('Page');
 		});
 	});
 });

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
 	Announcer,
 	PageAnnouncementOptions,
@@ -125,6 +125,13 @@ describe('getPageAnnouncement', () => {
 			document.title = '';
 			const announcement = getPageAnnouncement(defaults);
 			expect(announcement).toBe('Loaded page at /');
+		});
+
+		it('warns about missing heading', () => {
+			const warnMock = vi.spyOn(console, 'warn');
+			document.body.innerHTML = '';
+			getPageAnnouncement(defaults);
+			expect(warnMock).toHaveBeenCalledWith(expect.stringContaining('No main heading (h1) found on new page'));
 		});
 	});
 

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -49,7 +49,7 @@ describe('announcer', () => {
 			expect(announcer.region.textContent).toBe('Hello');
 		});
 
-		it('modifies the announcement to allow duplicate messages', async () => {
+		it('modifies each announcement to make it unique', async () => {
 			const announcer = new Announcer();
 			const region = announcer.region;
 

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -38,7 +38,7 @@ describe('announcer', () => {
 	});
 
 	describe('announce', () => {
-		it('returns a promise',  () => {
+		it('returns a promise', () => {
 			const announcer = new Announcer();
 			expect(announcer.announce('Hello')).toBeInstanceOf(Promise);
 		});
@@ -70,11 +70,11 @@ describe('getPageAnnouncement', () => {
 	};
 
 	const multiLangAnnouncements = {
-		en: {
+		'en': {
 			visit: 'Loaded {title}',
 			url: 'page at {url}'
 		},
-		de: {
+		'de': {
 			visit: '{title} geladen',
 			url: 'Seite unter {url}'
 		},

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Announcer, getPageAnnouncement } from '../../src/announcements.js';
 
 describe('announcer', () => {
@@ -59,6 +59,72 @@ describe('announcer', () => {
 			expect(region.textContent).toBe('Hello.');
 			await announcer.announce('Hello');
 			expect(region.textContent).toBe('Hello');
+		});
+	});
+});
+
+describe('getPageAnnouncement', () => {
+	const announcements = {
+		visit: 'Loaded {title}',
+		url: 'page at {url}'
+	};
+
+	const multiLangAnnouncements = {
+		en: {
+			visit: 'Loaded {title}',
+			url: 'page at {url}'
+		},
+		de: {
+			visit: '{title} geladen',
+			url: 'Seite unter {url}'
+		},
+		'*': {
+			visit: '{title}',
+			url: '{url}'
+		}
+	};
+
+	const defaults = { headingSelector: 'h1', announcements };
+
+	describe('headings', () => {
+		it('gets heading title', () => {
+			document.body.innerHTML = '<h1>Title</h1>';
+			const announcement = getPageAnnouncement(defaults);
+			expect(announcement).toBe('Loaded Title');
+		});
+
+		it('prefers heading label', () => {
+			document.body.innerHTML = '<h1 aria-label="Label">Title</h1>';
+			const announcement = getPageAnnouncement(defaults);
+			expect(announcement).toBe('Loaded Label');
+		});
+
+		it('uses heading selector', () => {
+			document.body.innerHTML = '<h2>Section</h2><h1>Title</h1>';
+			const announcement = getPageAnnouncement(defaults);
+			expect(announcement).toBe('Loaded Title');
+		});
+
+		it('makes heading selector configurable', () => {
+			document.body.innerHTML = '<h1>Title</h1><h2>Section</h2>';
+			const announcement = getPageAnnouncement({ ...defaults, headingSelector: 'h2' });
+			expect(announcement).toBe('Loaded Section');
+		});
+	});
+
+	describe('fallbacks', () => {
+		it('uses document title if no heading is found', () => {
+			document.title = 'Document';
+			document.body.innerHTML = '';
+			const announcement = getPageAnnouncement(defaults);
+			expect(announcement).toBe('Loaded Document');
+		});
+
+		it('uses url if no title is found', () => {
+			document.body.innerHTML = '';
+			document.title = '';
+			const announcement = getPageAnnouncement(defaults);
+			expect(announcement).toBe('Loaded page at /');
 		});
 	});
 });

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -131,7 +131,9 @@ describe('getPageAnnouncement', () => {
 			const warnMock = vi.spyOn(console, 'warn');
 			document.body.innerHTML = '';
 			getPageAnnouncement(defaults);
-			expect(warnMock).toHaveBeenCalledWith(expect.stringContaining('No main heading (h1) found on new page'));
+			expect(warnMock).toHaveBeenCalledWith(
+				expect.stringContaining('No main heading (h1) found on new page')
+			);
 		});
 	});
 

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
 	Announcer,
 	PageAnnouncementOptions,
@@ -6,10 +6,6 @@ import {
 } from '../../src/announcements.js';
 
 describe('announcer', () => {
-	afterEach(() => {
-		document.body.innerHTML = '';
-	});
-
 	describe('live region', () => {
 		it('creates an empty live region', () => {
 			const announcer = new Announcer();

--- a/tests/unit/createElement.test.ts
+++ b/tests/unit/createElement.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createElement } from '../../src/util.js';
 
 describe('createElement', () => {
-	it('should create an element from an html string', () => {
+	it('creates an element from an html string', () => {
 			const html = '<div id="test" class="my-class">Hello World</div>';
 			const element = createElement(html);
 			expect(element).not.toBeNull();
@@ -12,7 +12,7 @@ describe('createElement', () => {
 			expect(element.textContent).toBe('Hello World');
 	});
 
-	it('should create nothing if no html is passed', () => {
+	it('creates nothing if no html is passed', () => {
 			const element = createElement('');
 			expect(element).toBeUndefined();
 	});

--- a/tests/unit/createElement.test.ts
+++ b/tests/unit/createElement.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { createElement } from '../../src/util.js';
+
+describe('createElement', () => {
+	it('should create an element from an html string', () => {
+			const html = '<div id="test" class="my-class">Hello World</div>';
+			const element = createElement(html);
+			expect(element).not.toBeNull();
+			expect(element.localName).toBe('div');
+			expect(element.id).toBe('test');
+			expect(element.className).toBe('my-class');
+			expect(element.textContent).toBe('Hello World');
+	});
+
+	it('should create nothing if no html is passed', () => {
+			const element = createElement('');
+			expect(element).toBeUndefined();
+	});
+});

--- a/tests/unit/createElement.test.ts
+++ b/tests/unit/createElement.test.ts
@@ -3,17 +3,17 @@ import { createElement } from '../../src/util.js';
 
 describe('createElement', () => {
 	it('creates an element from an html string', () => {
-			const html = '<div id="test" class="my-class">Hello World</div>';
-			const element = createElement(html);
-			expect(element).not.toBeNull();
-			expect(element.localName).toBe('div');
-			expect(element.id).toBe('test');
-			expect(element.className).toBe('my-class');
-			expect(element.textContent).toBe('Hello World');
+		const html = '<div id="test" class="my-class">Hello World</div>';
+		const element = createElement(html);
+		expect(element).not.toBeNull();
+		expect(element.localName).toBe('div');
+		expect(element.id).toBe('test');
+		expect(element.className).toBe('my-class');
+		expect(element.textContent).toBe('Hello World');
 	});
 
 	it('creates nothing if no html is passed', () => {
-			const element = createElement('');
-			expect(element).toBeUndefined();
+		const element = createElement('');
+		expect(element).toBeUndefined();
 	});
 });

--- a/tests/unit/focus.test.ts
+++ b/tests/unit/focus.test.ts
@@ -1,18 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { focusElement } from '../../src/focus.js';
+import { focusElement, getAutofocusElement } from '../../src/focus.js';
+
+function create(html: string): HTMLElement[] {
+	document.body.innerHTML = html;
+	return Array.from(document.body.children) as HTMLElement[];
+}
 
 describe('focus', () => {
 	describe('focusElement', () => {
 		it('focuses an element', () => {
-			const element = document.createElement('button');
-			document.body.appendChild(element);
+			const [element] = create('<button></button>');
 			focusElement(element);
 			expect(document.activeElement).toBe(element);
 		});
 
 		it('accepts an element selector', () => {
-			const element = document.createElement('button');
-			document.body.appendChild(element);
+			const [element] = create('<button></button>');
 			focusElement('button');
 			expect(document.activeElement).toBe(element);
 		});
@@ -24,16 +27,13 @@ describe('focus', () => {
 		});
 
 		it('sets a tab index', () => {
-			const element = document.createElement('button');
-			document.body.appendChild(element);
+			const [element] = create('<button></button>');
 			focusElement(element);
 			expect(element.tabIndex).toBe(-1);
 		});
 
 		it('restores the previous tabindex', () => {
-			const element = document.createElement('button');
-			element.tabIndex = 4;
-			document.body.appendChild(element);
+			const [element] = create('<button tabindex="4"></button>');
 			focusElement(element);
 			expect(element.tabIndex).toBe(4);
 		});

--- a/tests/unit/focus.test.ts
+++ b/tests/unit/focus.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { focusElement } from '../../src/focus.js';
+
+describe('focus', () => {
+	describe('focusElement', () => {
+		it('focuses an element', () => {
+			const element = document.createElement('button');
+			document.body.appendChild(element);
+			focusElement(element);
+			expect(document.activeElement).toBe(element);
+		});
+
+		it('accepts an element selector', () => {
+			const element = document.createElement('button');
+			document.body.appendChild(element);
+			focusElement('button');
+			expect(document.activeElement).toBe(element);
+		});
+
+		it('fails silently for missing elements', () => {
+			// @ts-expect-error invalid argument
+			expect(() => focusElement(null)).not.toThrow();
+			expect(() => focusElement('input')).not.toThrow();
+		});
+
+		it('sets a tab index', () => {
+			const element = document.createElement('button');
+			document.body.appendChild(element);
+			focusElement(element);
+			expect(element.tabIndex).toBe(-1);
+		});
+
+		it('restores the previous tabindex', () => {
+			const element = document.createElement('button');
+			element.tabIndex = 4;
+			document.body.appendChild(element);
+			focusElement(element);
+			expect(element.tabIndex).toBe(4);
+		});
+	});
+});

--- a/tests/unit/focus.test.ts
+++ b/tests/unit/focus.test.ts
@@ -38,4 +38,26 @@ describe('focus', () => {
 			expect(element.tabIndex).toBe(4);
 		});
 	});
+
+	describe('getAutofocusElement', () => {
+		it('finds the first autofocus element', () => {
+			const [first] = create('<button autofocus></button><input autofocus>');
+			expect(getAutofocusElement()).toBe(first);
+		});
+
+		it('ignores elements in inert containers', () => {
+			create('<div inert><button autofocus></button></div>');
+			expect(getAutofocusElement()).toBeUndefined();
+		});
+
+		it('ignores elements in aria-disabled containers', () => {
+			create('<div aria-disabled><button autofocus></button></div>');
+			expect(getAutofocusElement()).toBeUndefined();
+		});
+
+		it('ignores elements in aria-hidden containers', () => {
+			create('<div aria-hidden="true"><button autofocus></button></div>');
+			expect(getAutofocusElement()).toBeUndefined();
+		});
+	});
 });

--- a/tests/unit/focus.test.ts
+++ b/tests/unit/focus.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { focusElement, getAutofocusElement } from '../../src/focus.js';
+import { describe, expect, it, vi } from 'vitest';
+import { focusAutofocusElement, focusElement, getAutofocusElement } from '../../src/focus.js';
 
 function create(html: string): HTMLElement[] {
 	document.body.innerHTML = html;
@@ -12,6 +12,13 @@ describe('focus', () => {
 			const [element] = create('<button></button>');
 			focusElement(element);
 			expect(document.activeElement).toBe(element);
+		});
+
+		it('prevents scroll on focus', () => {
+			const [element] = create('<button></button>');
+			const focusMock = vi.spyOn(element, 'focus');
+			focusElement(element);
+			expect(focusMock).toHaveBeenCalledWith({ preventScroll: true });
 		});
 
 		it('accepts an element selector', () => {
@@ -58,6 +65,15 @@ describe('focus', () => {
 		it('ignores elements in aria-hidden containers', () => {
 			create('<div aria-hidden="true"><button autofocus></button></div>');
 			expect(getAutofocusElement()).toBeUndefined();
+		});
+	});
+
+	describe('focusAutofocusElement', () => {
+		it('focuses the autofocus element', () => {
+			const [element] = create('<button autofocus></button>');
+			const focusMock = vi.spyOn(element, 'focus');
+			focusAutofocusElement();
+			expect(focusMock).toHaveBeenCalledWith();
 		});
 	});
 });

--- a/tests/unit/parseTemplate.test.ts
+++ b/tests/unit/parseTemplate.test.ts
@@ -2,28 +2,28 @@ import { describe, expect, it } from 'vitest';
 import { parseTemplate } from '../../src/util.js';
 
 describe('parseTemplate', () => {
-	it('should replace placeholders with values', () => {
+	it('replaces placeholders with values', () => {
 		const template = 'My friend {name} is {age} years old';
 		const replacements = { name: 'John', age: '30' };
 		const result = parseTemplate(template, replacements);
 		expect(result).toBe('My friend John is 30 years old');
 	});
 
-	it('should accept any-case value keys', () => {
+	it('accepts any-case value keys', () => {
 		const template = 'My friend {Name} is {Age} years old';
 		const replacements = { Name: 'John', Age: '30' };
 		const result = parseTemplate(template, replacements);
 		expect(result).toBe('My friend John is 30 years old');
 	});
 
-	it('should ignore missing value keys', () => {
+	it('ignores missing value keys', () => {
 		const template = 'Hello, {name}!';
 		const replacements = {};
 		const result = parseTemplate(template, replacements);
 		expect(result).toBe('Hello, {name}!');
 	});
 
-	it('should throw when no data is provided', () => {
+	it('throws when no data is provided', () => {
 		// @ts-expect-error missing argument
 		expect(() => parseTemplate('Hello, {name}!')).toThrow();
 	});

--- a/tests/unit/parseTemplate.test.ts
+++ b/tests/unit/parseTemplate.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { parseTemplate } from '../../src/util.js';
+
+describe('parseTemplate', () => {
+	it('should replace placeholders with values', () => {
+		const template = 'My friend {name} is {age} years old';
+		const replacements = { name: 'John', age: '30' };
+		const result = parseTemplate(template, replacements);
+		expect(result).toBe('My friend John is 30 years old');
+	});
+
+	it('should accept any-case value keys', () => {
+		const template = 'My friend {Name} is {Age} years old';
+		const replacements = { Name: 'John', Age: '30' };
+		const result = parseTemplate(template, replacements);
+		expect(result).toBe('My friend John is 30 years old');
+	});
+
+	it('should ignore missing value keys', () => {
+		const template = 'Hello, {name}!';
+		const replacements = {};
+		const result = parseTemplate(template, replacements);
+		expect(result).toBe('Hello, {name}!');
+	});
+
+	it('should throw when no data is provided', () => {
+		// @ts-expect-error missing argument
+		expect(() => parseTemplate('Hello, {name}!')).toThrow();
+	});
+});

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -86,7 +86,7 @@ describe('SwupA11yPlugin', () => {
 		});
 	});
 
-	describe('focus', async () => {
+	describe('content focus', async () => {
 		let autofocusElementFound = false;
 		const focus = await import('../../src/focus.js');
 		focus.focusAutofocusElement = vitest.fn().mockImplementation(() => autofocusElementFound);
@@ -210,6 +210,18 @@ describe('SwupA11yPlugin', () => {
 			await swup.hooks.call('visit:end', visit, undefined);
 
 			expect(announcerMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('anchor focus', async () => {
+		const focus = await import('../../src/focus.js');
+		focus.focusElement = vitest.fn();
+
+		it('focuses anchor target from scroll:anchor hook', async () => {
+			document.body.innerHTML = '<a href="#target"></a><div id="target"></div>';
+			await swup.hooks.call('scroll:anchor', visit, { hash: '#target', options: {} });
+
+			expect(focus.focusElement).toHaveBeenCalledWith(expect.any(HTMLDivElement));
 		});
 	});
 });

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -174,7 +174,10 @@ describe('SwupA11yPlugin', () => {
 			await swup.hooks.call('visit:start', visit, undefined);
 			await swup.hooks.call('visit:end', visit, undefined);
 
-			expect(announcerMock).toHaveBeenCalledWith(visit.a11y.announce, plugin.announcementDelay);
+			expect(announcerMock).toHaveBeenCalledWith(
+				visit.a11y.announce,
+				plugin.announcementDelay
+			);
 		});
 
 		it('triggers content:announce hook from visit:end hook', async () => {

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -1,0 +1,149 @@
+import { vitest, describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { setMedia } from 'mock-match-media';
+
+import Swup, { Visit } from 'swup';
+
+import SwupA11yPlugin from '../../src/index.js';
+import { Announcer } from '../../src/announcements.js';
+
+vitest.mock('../../src/announcements.js');
+vitest.mock('../../src/focus.js');
+
+const page = { page: { html: '', url: '/' } };
+
+describe('SwupA11yPlugin', () => {
+	let swup: Swup;
+	let plugin: SwupA11yPlugin;
+	let visit: Visit;
+
+	beforeEach(() => {
+		swup = new Swup();
+		plugin = new SwupA11yPlugin();
+		swup.use(plugin);
+		// @ts-ignore - createVisit is marked internal
+		visit = swup.createVisit({ url: '/' });
+		visit.to.document = new window.DOMParser().parseFromString(
+			'<html><head></head><body></body></html>',
+			'text/html'
+		);
+	});
+
+	afterEach(() => {
+		swup.unuse(plugin);
+		swup.destroy();
+	});
+
+	describe('hooks', () => {
+		it('creates new hooks', async () => {
+			expect(swup.hooks.exists('content:announce')).toBe(true);
+			expect(swup.hooks.exists('content:focus')).toBe(true);
+		});
+	});
+
+	describe('visit object', () => {
+		it('adds an a11y key to the visit object', async () => {
+			await swup.hooks.call('visit:start', visit, undefined);
+			expect(visit).toMatchObject({
+				a11y: {
+					announce: undefined,
+					focus: 'body'
+				}
+			});
+		});
+	});
+
+	describe('announcements', () => {
+		it('creates an announcer instance', async () => {
+			expect(plugin.announcer).toBeInstanceOf(Announcer);
+		});
+
+		it('adds an announce method to swup', async () => {
+			expect(swup.announce).toBeInstanceOf(Function);
+			const announcerMock = vi.spyOn(plugin.announcer, 'announce');
+			await swup.announce!('Hello');
+			expect(announcerMock).toHaveBeenCalledWith('Hello');
+		});
+	});
+
+	describe('busy', () => {
+		it('marks page as busy during transitions', async () => {
+			await swup.hooks.call('visit:start', visit, undefined);
+			expect(document.documentElement.getAttribute('aria-busy')).toBe('true');
+
+			await swup.hooks.call('visit:end', visit, undefined);
+			expect(document.documentElement.getAttribute('aria-busy')).toBeNull();
+		});
+	});
+
+	describe('reduced motion', () => {
+		it('ignores animations when reduced motion is unset', async () => {
+			await swup.hooks.call('visit:start', visit, undefined);
+			expect(visit.animation).toMatchObject({ animate: true });
+			expect(visit.scroll).not.toHaveProperty('animate');
+		});
+
+		it('disables animations when reduced motion is preferred', async () => {
+			setMedia({ 'prefers-reduced-motion': 'reduce' });
+			await swup.hooks.call('visit:start', visit, undefined);
+			expect(visit.animation).toMatchObject({ animate: false });
+			expect(visit.scroll).toMatchObject({ animate: false });
+		});
+
+		it('ignores animations when reduced motion setting is disabled', async () => {
+			setMedia({ 'prefers-reduced-motion': 'reduce' });
+			plugin.options.respectReducedMotion = false;
+			await swup.hooks.call('visit:start', visit, undefined);
+			expect(visit.animation).toMatchObject({ animate: true });
+			expect(visit.scroll).not.toHaveProperty('animate');
+		});
+	});
+
+	describe('focus', async () => {
+		let autofocusElementFound = false;
+		const focus = await import('../../src/focus.js');
+		focus.focusAutofocusElement = vitest.fn().mockImplementation(() => autofocusElementFound);
+		focus.focusElement = vitest.fn();
+
+		it('calls focusElement from visit:end hook', async () => {
+			await swup.hooks.call('visit:start', visit, undefined);
+			await swup.hooks.call('visit:end', visit, undefined);
+
+			expect(focus.focusElement).toHaveBeenCalledWith(visit.a11y.focus);
+		});
+
+		it('ignores empty focus selector', async () => {
+			await swup.hooks.call('visit:start', visit, undefined);
+			visit.a11y.focus = '';
+			await swup.hooks.call('visit:end', visit, undefined);
+
+			expect(focus.focusElement).not.toHaveBeenCalled();
+		});
+
+		it('does not autofocus from visit:end by default', async () => {
+			await swup.hooks.call('visit:start', visit, undefined);
+			await swup.hooks.call('visit:end', visit, undefined);
+
+			expect(focus.focusAutofocusElement).not.toHaveBeenCalled();
+		});
+
+		it('autofocuses from visit:end hook if configured', async () => {
+			plugin.options.autofocus = true;
+			await swup.hooks.call('visit:start', visit, undefined);
+			await swup.hooks.call('visit:end', visit, undefined);
+
+			expect(focus.focusAutofocusElement).toHaveBeenCalled();
+			expect(focus.focusElement).toHaveBeenCalled();
+		});
+
+		it('skips normal focus if autofocus element was found', async () => {
+			plugin.options.autofocus = true;
+			autofocusElementFound = true;
+			await swup.hooks.call('visit:start', visit, undefined);
+			await swup.hooks.call('visit:end', visit, undefined);
+
+			expect(focus.focusAutofocusElement).toHaveBeenCalled();
+			expect(focus.focusElement).not.toHaveBeenCalled();
+		});
+	});
+
+});


### PR DESCRIPTION
**Description**

- Add tests and fix a few issues discovered during testing
- Turns out we can test the whole plugin just in vite, same as the head plugin
- Avoiding Playwright for as long as possible makes things much simpler and faster 🧃

**Changes**

- Straighten out a few types
- Make `swup.announce()` return a Promise to simplify testing
- Check reduced-motion option just-in-time to simplify testing
- Extract announcement delay into documented variable

**Fixes**

- Re-implement language fallback
- Fix selector for `[inert]` autofocus element

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [ ] ~~The documentation was updated as required~~

**Notes**

Closes #58 