### PR TITLE
Fix language fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.5.2] - 2024-04-15
+
+- Use fallback announcement for unknown languages
+
 ## [4.5.1] - 2024-04-02
 
 - Fix the type signature of `AnnouncementTranslations`
@@ -54,6 +58,7 @@
 
 - Initial release
 
+[4.5.2]: https://github.com/swup/a11y-plugin/releases/tag/4.5.2
 [4.5.1]: https://github.com/swup/a11y-plugin/releases/tag/4.5.1
 [4.5.0]: https://github.com/swup/a11y-plugin/releases/tag/4.5.0
 [4.4.2]: https://github.com/swup/a11y-plugin/releases/tag/4.4.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swup/a11y-plugin",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@swup/a11y-plugin",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "MIT",
       "dependencies": {
         "@swup/plugin": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swup/a11y-plugin",
   "amdName": "SwupA11yPlugin",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "A swup plugin for enhanced accessibility",
   "type": "module",
   "source": "src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,8 +85,8 @@ export default class SwupA11yPlugin extends Plugin {
 		// Merge deprecated announcement templates into new structure
 		options.announcements = {
 			...this.defaults.announcements,
-			visit: options.announcementTemplate ?? this.defaults.announcements.visit,
-			url: options.urlTemplate ?? this.defaults.announcements.url,
+			visit: options.announcementTemplate ?? String(this.defaults.announcements.visit),
+			url: options.urlTemplate ?? String(this.defaults.announcements.url),
 			...options.announcements
 		};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,9 @@ export default class SwupA11yPlugin extends Plugin {
 		const lang = document.documentElement.lang || '*';
 
 		const templates: Announcements =
-			(announcements as AnnouncementTranslations)[lang] || announcements;
+			(announcements as AnnouncementTranslations)[lang] ||
+			(announcements as AnnouncementTranslations)['*'] ||
+			announcements;
 		if (typeof templates !== 'object') return;
 
 		// Look for first heading in content container


### PR DESCRIPTION
**Description**

- Correctly fall back to the missing-language announcement templates
- Nice to publish this as a last patch release
- Includes version bump and changelog entry

**Question**

- How do we merge & publish this? The `master` branch already has the next major release in it
- Should have created a `next` branch like before 😭
- Probably we need to create a tag on the `version/automated` branch, and release from that tag

**Checks**

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
- [ ] ~~All tests are passing (`npm run test`)~~
- [ ] ~~New or updated tests are included~~
- [ ] ~~The documentation was updated as required~~

**Additional information**

Closes #58 