### PR TITLE
Prioritize headings inside `main` element

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ All options with their default values:
 
 ```javascript
 {
-  headingSelector: 'h1',
+  headingSelector: ['main h1', 'h1'],
   respectReducedMotion: true,
   autofocus: false,
   announcements: {
@@ -123,7 +123,8 @@ All options with their default values:
 ### headingSelector
 
 The selector for finding page headings. The content of the first found heading will be read to
-screenreaders after a new page was loaded.
+screenreaders after a new page was loaded. The default selector uses an array to prioritize
+headings inside the `main` element.
 
 ### respectReducedMotion
 

--- a/src/announcements.ts
+++ b/src/announcements.ts
@@ -56,9 +56,15 @@ export function getPageAnnouncement({
 	if (typeof templates !== 'object') return;
 
 	// Look for first heading on page
-	const headingEl = document.querySelector(headingSelector);
+	const selectors = Array.isArray(headingSelector) ? headingSelector : [headingSelector];
+	const headingEl = selectors.reduce(
+		(found, selector) => found ?? document.querySelector(selector),
+		null as Element | null
+	);
 	if (!headingEl) {
-		console.warn(`SwupA11yPlugin: No main heading (${headingSelector}) found on new page`);
+		console.warn(
+			`SwupA11yPlugin: No main heading (${selectors.join(' / ')}) found on new page`
+		);
 	}
 
 	// Get page heading from aria attribute or text content

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ export default class SwupA11yPlugin extends Plugin {
 	requires = { swup: '>=4' };
 
 	defaults: Options = {
-		headingSelector: 'h1',
+		headingSelector: ['main h1', 'h1'],
 		respectReducedMotion: true,
 		autofocus: false,
 		announcements: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,8 @@ export type AnnouncementTranslations = {
 };
 
 export type Options = {
-	/** The selector for finding headings inside the main content area. */
-	headingSelector: string;
+	/** The selector for finding headings inside the main content area. Use an array to try different selectors in order. */
+	headingSelector: string | string[];
 	/** Whether to skip animations for users that prefer reduced motion. */
 	respectReducedMotion: boolean;
 	/** How to announce the new page title and url. */

--- a/tests/unit/announcements.test.ts
+++ b/tests/unit/announcements.test.ts
@@ -110,6 +110,15 @@ describe('getPageAnnouncement', () => {
 			const announcement = getPageAnnouncement({ ...defaults, headingSelector: 'h2' });
 			expect(announcement).toBe('Loaded Section');
 		});
+
+		it('tries different selectors in order', () => {
+			document.body.innerHTML = '<h1>Logo</h1><main><h1>Title</h1></main>';
+			const announcement = getPageAnnouncement({
+				...defaults,
+				headingSelector: ['main h1', 'h1']
+			});
+			expect(announcement).toBe('Loaded Title');
+		});
 	});
 
 	describe('fallbacks', () => {


### PR DESCRIPTION
**Description**

- Add the ability to try multiple heading selectors in order
- This was required in a recent project without control over markup to properly handle some weird markup
- I figured this would also be a good defensive default: first `main h1`, then `h1`
- No breaking change: it falls back to the previous version; strings are still accepted as a user option

**Checks**

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required
