### PR TITLE
Add `visit.a11y.focus.wait`

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,7 @@ The text to announce after the new page was loaded. This is the final text after
 correct language from the [announcements](#announcements) option and filling in any placeholders.
 Modify it to read a custom announcement.
 
-Since the text can only be populated once the new page was fetched and its contents are available,
-the only place to inspect or modify this would be right before the `content:announce` hook.
+Since the text can only be populated once the new page was fetched and its contents are available, the only place to inspect or modify this would be right before the `content:announce` hook.
 
 ```js
 swup.hooks.before('content:announce', (visit) => {
@@ -236,13 +235,19 @@ swup.hooks.before('content:announce', (visit) => {
 
 Type: `Object` | `string` | `false`, Default: `Object`
 
-Controls what element to focus after the new page has loaded, and when. Defaults to the `body` after the visit has settled:
+Controls what element to focus after the new page has loaded, and when. Defaults moving the focus to the `<body>` on `visit:end`. Customize like so:
 
 ```js
-visit.focus = {
-  selector: 'body',
-  wait: true
-};
+swup.hooks.on('visit:start', (visit) => {
+  if (someCondition()) {
+    visit.a11y.focus = {
+      /** focus <main> instead of <body> */
+      selector: 'main',
+      /** apply focus immeditely after 'content:replace' instead of waiting until 'visit:end' */
+      wait: false
+    };
+  }
+});
 ```
 
 Can be customized per visit. Set `wait` to false to apply focus immediately after `content:replace`. Change `selector` to focus another element. Or disable focus handling altogether by setting `visit.focus = false`.

--- a/README.md
+++ b/README.md
@@ -207,12 +207,17 @@ behavior on the fly.
   to: { ... },
   a11y: {
     announce: 'Navigated to: About',
-    focus: 'body'
+    focus: {
+      selector: 'body',
+      wait: true
+    }
   }
 }
 ```
 
 ### visit.a11y.announce
+
+Type: `string` | `false` | `undefined`
 
 The text to announce after the new page was loaded. This is the final text after choosing the
 correct language from the [announcements](#announcements) option and filling in any placeholders.
@@ -229,9 +234,18 @@ swup.hooks.before('content:announce', (visit) => {
 
 ### visit.a11y.focus
 
-The element to receive focus after the new page was loaded, by default the `body`. Can be customized
-per visit. Set it to a selector `string` to select an element, or set it to `false` to not move the
-focus on this visit.
+Type: `Object` | `string` | `false`, Default: `Object`
+
+Controls what element to focus after the new page has loaded, and when. Defaults to the `body` after the visit has settled:
+
+```js
+visit.focus = {
+  selector: 'body',
+  wait: true
+}
+```
+
+Can be customized per visit. Set `wait` to false to apply focus immediately after `content:replace`. Change `selector` to focus another element. Or disable focus handling altogether by setting `visit.focus = false`.
 
 ## Hooks
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ swup.hooks.before('content:announce', (visit) => {
 
 Type: `Object` | `string` | `false`, Default: `Object`
 
-Controls what element to focus after the new page has loaded, and when. Defaults moving the focus to the `<body>` on `visit:end`. Customize like so:
+Customize which element to focus after the new page has loaded, and when. Defaults moving the focus to the `<body>` on `visit:end`:
 
 ```js
 swup.hooks.on('visit:start', (visit) => {
@@ -250,7 +250,7 @@ swup.hooks.on('visit:start', (visit) => {
 });
 ```
 
-Can be customized per visit. Set `wait` to false to apply focus immediately after `content:replace`. Change `selector` to focus another element. Or disable focus handling altogether by setting `visit.focus = false`.
+Set `visit.focus = false` to completely disable focus handling.
 
 ## Hooks
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Controls what element to focus after the new page has loaded, and when. Defaults
 visit.focus = {
   selector: 'body',
   wait: true
-}
+};
 ```
 
 Can be customized per visit. Set `wait` to false to apply focus immediately after `content:replace`. Change `selector` to focus another element. Or disable focus handling altogether by setting `visit.focus = false`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10577,24 +10577,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,22 @@ import { Announcer, getPageAnnouncement } from './announcements.js';
 import { focusAutofocusElement, focusElement } from './focus.js';
 import { prefersReducedMotion } from './util.js';
 
+type VisitFocus = {
+	/** the element selector to focus */
+	selector: string;
+	/** wait until "visit:end" before focusing? Default: true */
+	wait: boolean;
+}
+
 export interface VisitA11y {
 	/** How to announce the new content after it inserted */
 	announce: string | false | undefined;
-	/** The element to focus after the content is replaced */
-	focus: string | false;
+	/**
+	 * How to move focus after the content is replaced
+	 * - pass a string to focus an element
+	 * - pass an object for more control
+	 */
+	focus: string | false | VisitFocus;
 }
 
 declare module 'swup' {
@@ -110,8 +121,9 @@ export default class SwupA11yPlugin extends Plugin {
 		this.on('visit:start', this.markAsBusy);
 		this.on('visit:end', this.unmarkAsBusy);
 
-		// Focus new page content after visit completes
-		this.on('visit:end', this.focusContent);
+		// Focus new page content, based on `visit.a11y.focus`
+		this.on('content:replace', this.maybeFocusEarly);
+		this.on('visit:end', this.maybeFocusLate);
 
 		// Announce new page title after visit completes
 		this.on('visit:end', this.announceContent);
@@ -147,7 +159,10 @@ export default class SwupA11yPlugin extends Plugin {
 	prepareVisit(visit: Visit) {
 		visit.a11y = {
 			announce: undefined,
-			focus: this.rootSelector
+			focus: {
+				selector: this.rootSelector,
+				wait: true,
+			}
 		};
 	}
 
@@ -164,16 +179,41 @@ export default class SwupA11yPlugin extends Plugin {
 		});
 	}
 
+	maybeFocusEarly(visit: Visit) {
+		const focus = this.parseVisitFocus(visit.a11y.focus);
+		if (focus && !focus.wait) this.focusContent(visit);
+	}
+
+	maybeFocusLate(visit: Visit) {
+		const focus = this.parseVisitFocus(visit.a11y.focus);
+		if (focus && focus.wait) this.focusContent(visit);
+	}
+
 	focusContent(visit: Visit) {
 		this.swup.hooks.callSync('content:focus', visit, undefined, (visit) => {
-			if (!visit.a11y.focus) return;
+			const focus = this.parseVisitFocus(visit.a11y.focus);
+			if (!focus) return;
 
 			// Found and focused [autofocus] element? Return early
 			if (this.options.autofocus && focusAutofocusElement() === true) return;
 
 			// Otherwise, find and focus actual content container
-			focusElement(visit.a11y.focus);
+			focusElement(focus.selector);
 		});
+	}
+
+	/**
+	 * parse `visit.focus`
+	 */
+	parseVisitFocus(value: false | string | VisitFocus): false | VisitFocus {
+		if (!value) return false;
+
+		const focus = typeof value === 'string' ? {
+			selector: value,
+			wait: true,
+		} : value;
+
+		return !focus.selector ? false : focus;
 	}
 
 	handleAnchorScroll: HookHandler<'scroll:anchor'> = (visit, { hash }) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ type VisitFocus = {
 	selector: string;
 	/** wait until "visit:end" before focusing? Default: true */
 	wait: boolean;
-}
+};
 
 export interface VisitA11y {
 	/** How to announce the new content after it inserted */
@@ -161,7 +161,7 @@ export default class SwupA11yPlugin extends Plugin {
 			announce: undefined,
 			focus: {
 				selector: this.rootSelector,
-				wait: true,
+				wait: true
 			}
 		};
 	}
@@ -208,10 +208,13 @@ export default class SwupA11yPlugin extends Plugin {
 	parseVisitFocus(value: false | string | VisitFocus): false | VisitFocus {
 		if (!value) return false;
 
-		const focus = typeof value === 'string' ? {
-			selector: value,
-			wait: true,
-		} : value;
+		const focus =
+			typeof value === 'string'
+				? {
+						selector: value,
+						wait: true
+					}
+				: value;
 
 		return !focus.selector ? false : focus;
 	}

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -1,4 +1,4 @@
-import { vitest, describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { vitest, describe, expect, it, beforeEach, afterEach, vi, MockInstance } from 'vitest';
 import { setMedia } from 'mock-match-media';
 
 import Swup, { Visit } from 'swup';
@@ -152,7 +152,7 @@ describe('SwupA11yPlugin', () => {
 	});
 
 	describe('announcements', async () => {
-		let announcerMock;
+		let announcerMock: MockInstance;
 		const announcements = await import('../../src/announcements.js');
 		announcements.getPageAnnouncement = vitest.fn().mockImplementation(() => 'Hello');
 

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -71,14 +71,14 @@ describe('SwupA11yPlugin', () => {
 		});
 
 		it('disables animations when reduced motion is preferred', async () => {
-			setMedia({ 'prefers-reduced-motion': 'reduce' });
+			setMedia({ prefersReducedMotion: 'reduce' });
 			await swup.hooks.call('visit:start', visit, undefined);
 			expect(visit.animation).toMatchObject({ animate: false });
 			expect(visit.scroll).toMatchObject({ animate: false });
 		});
 
 		it('ignores animations when reduced motion setting is disabled', async () => {
-			setMedia({ 'prefers-reduced-motion': 'reduce' });
+			setMedia({ prefersReducedMotion: 'reduce' });
 			plugin.options.respectReducedMotion = false;
 			await swup.hooks.call('visit:start', visit, undefined);
 			expect(visit.animation).toMatchObject({ animate: true });

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -92,9 +92,20 @@ describe('SwupA11yPlugin', () => {
 		focus.focusAutofocusElement = vitest.fn().mockImplementation(() => autofocusElementFound);
 		focus.focusElement = vitest.fn();
 
-		it('focuses element from visit:end hook', async () => {
+		it('applies focus on visit:end by default', async () => {
 			await swup.hooks.call('visit:start', visit, undefined);
 			await swup.hooks.call('visit:end', visit, undefined);
+
+			expect(focus.focusElement).toHaveBeenCalledWith('body');
+		});
+
+		it('applies focus on content:replace if configured', async () => {
+			await swup.hooks.call('visit:start', visit, undefined);
+			visit.a11y.focus = {
+				selector: 'body',
+				wait: false,
+			};
+			await swup.hooks.call('content:replace', visit, { page: { url: '/', html: '' } });
 
 			expect(focus.focusElement).toHaveBeenCalledWith('body');
 		});
@@ -119,6 +130,14 @@ describe('SwupA11yPlugin', () => {
 		it('ignores empty focus selector', async () => {
 			await swup.hooks.call('visit:start', visit, undefined);
 			visit.a11y.focus = '';
+			await swup.hooks.call('visit:end', visit, undefined);
+
+			expect(focus.focusElement).not.toHaveBeenCalled();
+		});
+
+		it('ignores empty focus.selector selector', async () => {
+			await swup.hooks.call('visit:start', visit, undefined);
+			visit.a11y.focus = { selector: '', wait: true };
 			await swup.hooks.call('visit:end', visit, undefined);
 
 			expect(focus.focusElement).not.toHaveBeenCalled();

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -103,7 +103,7 @@ describe('SwupA11yPlugin', () => {
 			await swup.hooks.call('visit:start', visit, undefined);
 			visit.a11y.focus = {
 				selector: 'body',
-				wait: false,
+				wait: false
 			};
 			await swup.hooks.call('content:replace', visit, { page: { url: '/', html: '' } });
 

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -71,14 +71,14 @@ describe('SwupA11yPlugin', () => {
 		});
 
 		it('disables animations when reduced motion is preferred', async () => {
-			setMedia({ prefersReducedMotion: 'reduce' });
+			setMedia({ 'prefers-reduced-motion': 'reduce' });
 			await swup.hooks.call('visit:start', visit, undefined);
 			expect(visit.animation).toMatchObject({ animate: false });
 			expect(visit.scroll).toMatchObject({ animate: false });
 		});
 
 		it('ignores animations when reduced motion setting is disabled', async () => {
-			setMedia({ prefersReducedMotion: 'reduce' });
+			setMedia({ 'prefers-reduced-motion': 'reduce' });
 			plugin.options.respectReducedMotion = false;
 			await swup.hooks.call('visit:start', visit, undefined);
 			expect(visit.animation).toMatchObject({ animate: true });

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -47,7 +47,7 @@ describe('SwupA11yPlugin', () => {
 			expect(visit).toMatchObject({
 				a11y: {
 					announce: undefined,
-					focus: 'body'
+					focus: { selector: 'body', wait: true }
 				}
 			});
 		});
@@ -96,7 +96,7 @@ describe('SwupA11yPlugin', () => {
 			await swup.hooks.call('visit:start', visit, undefined);
 			await swup.hooks.call('visit:end', visit, undefined);
 
-			expect(focus.focusElement).toHaveBeenCalledWith(visit.a11y.focus);
+			expect(focus.focusElement).toHaveBeenCalledWith('body');
 		});
 
 		it('triggers content:focus hook from visit:end hook', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "resolveJsonModule": true,                           /* Enable importing .json files. */
     "allowJs": true,                                     /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
+    "rootDir": ".",
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "strict": true,                                      /* Enable all strict type-checking options. */
     "noImplicitAny": true                                /* Enable error reporting for expressions and declarations with an implied 'any' type. */


### PR DESCRIPTION
Closes #93 

**Description**

Add support to control _when_ to set the focus during the visit lifecycle:

```js
swup.hooks.on('visit:start', (visit) => {
  if (someCondition()) {
    visit.a11y.focus = {
      /** focus <main> instead of <body> */
      selector: 'main',
      /** apply focus immediately after 'content:replace' instead of waiting until 'visit:end' */
      wait: false
    };
  }
});
```

- The default shape of `visit.a11y.focus` is now `{ selector: 'body', wait: true }`
- Support for setting `focus` to a `string` is retained for backwards compatibility 

**drive-by**

- Added `rootDir` to the tsconfig (vs code was complaining)
- Fixed a few type issues in the test files
- ~Fixed a previously-existing failing test for `'prefers-reduced-motion'`~ Ran `npm update` instead, this seems to have fixed the error

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `main` branch
- [x] The code was linted before pushing (`npm run lint`)
- [x] All tests are passing (`npm run test`)
- [x] New or updated tests are included
- [x] The documentation was updated as required
